### PR TITLE
Allow for longer time to pause commander

### DIFF
--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -251,7 +251,7 @@ def pause_commander(db):
             logging.error('Commander failed to pause!')
             doc.delete()
             logging.info('Commander control doc {_id} successfully deleted'.format(**doc))
-            sys.exit(return_code)
+            sys.exit(-1)
             return None
         doc.reload()
     return doc['_id']


### PR DESCRIPTION
The 24 * 5s = 2 min wait for the commander to pause is not sufficient, so I changed it to 30 * 60s = 30 min.

I also fixed a bug that only rears its head when the commander fails to pause.