### PR TITLE
Wait longer for the commander to pause

### DIFF
--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -237,8 +237,8 @@ def sync_all_tallies(db):
     logging.info('Done syncing all tallies')
 
 def pause_commander(db):
-    PAUSE_ITERATION_LIMIT = 30          # number of iterations to wait before giving up
-    PAUSE_ITERATION_WAIT_SECONDS = 60   # number of seconds to wait between each check to see if the commander has paused
+    PAUSE_ITERATION_LIMIT = 10          # number of iterations to wait before giving up
+    PAUSE_ITERATION_WAIT_SECONDS = 1800 # number of seconds to wait between each check to see if the commander has paused
     pause_iteration_count = 0
     ch = CHDatabase(db)
     doc = ch.pause_commander('create_snapshots_reports_scorecard', 'report generation')


### PR DESCRIPTION
Lengthen the amount of time that the reporting script waits for the commander to pause.

This is necessary because the commander is taking about 1600 seconds to pause right now.