### PR TITLE
Create reports where new volume is mounted

### DIFF
--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -45,7 +45,7 @@ REPORT_THREADS = 16
 NCATS_DHUB_URL = 'dhub.ncats.cyber.dhs.gov:5001'
 NCATS_WEB_URL = 'web.data.ncats.cyber.dhs.gov'
 
-WEEKLY_REPORT_BASE_DIR = '/var/cyhy/reports'
+WEEKLY_REPORT_BASE_DIR = '/var/cyhy/reports/output'
 SCORECARD_OUTPUT_DIR =  'scorecards'
 SCORECARD_JSON_OUTPUT_DIR = 'JSONfiles'
 CYBEX_CSV_DIR = 'cybex_csvs'


### PR DESCRIPTION
Create everything in the `/var/cyhy/reports/output` directory, which is where the new reports volume is mounted.

This pull request goes along with dhs-ncats/cyhy_amis#110.