### PR TITLE
Remove ED 19-01 data for suborgs

### DIFF
--- a/cyhy_report/customer/report.mustache
+++ b/cyhy_report/customer/report.mustache
@@ -666,30 +666,30 @@ supporting the directive by providing certificate information found in
 \gls{CT} log entries for known agency second-level domains and all
 subdomains under them. Per the directive, agencies shall monitor
 \gls{CT} log data for certificates issued that they did not request.
-<<#display_owner>>
+<<^is_suborg>>
 Detailed information on the certificates discovered by \gls{NCATS} can
 be found in the
 \hyperref[app:attachments]{\texttt{certificates.csv}} attachment
 within the agency’s weekly Cyber Hygiene report.
-<</display_owner>>
-<<^display_owner>>
+<</is_suborg>>
+<<#is_suborg>>
 We have no way to associate an organization's second-level domains
 with its various sub-organizations, so all domains are reported within
 the parent organization's overall weekly Cyber Hygiene report.  You
 may need to contact your technical POC(s) listed in Section
 \ref{subsec:points-of-contact} of this report to get the detailed
 information for your sub-organization's domains.
-<</display_owner>>
+<</is_suborg>>
 
-<<#display_owner>>
+<<^is_suborg>>
 We recommend focusing on validating that newly-added certificates were
 purposefully issued; new certificates issued without a known purpose
 may indicate \gls{DNS} infrastructure tampering. The issuing
 organization table is included to help identify possible outlier
 certificates that have been issued by an unusual organization.
-<</display_owner>>
+<</is_suborg>>
 
-<<#display_owner>>
+<<^is_suborg>>
 {\RCHeadB\color{dhs-dark-gray} HIGH LEVEL FINDINGS\\
 \RCHashThick}\\
 \begin{minipage}[b]{0.45\textwidth}
@@ -770,7 +770,7 @@ certificates that have been issued by an unusual organization.
   \multicolumn{2}{|c|}{\emph{No certificates}}\\
   <</certs.ca_aggregation>>
 \end{longtable}
-<</display_owner>>
+<</is_suborg>>
 <</owner_is_federal_executive>>
 
 %\twocolumn
@@ -1529,10 +1529,10 @@ This section seeks to answer the most frequently asked questions about Cyber Hyg
 If your PDF viewer supports embedded attachments you will see paperclip icons below for each attached file.
 \begin{itemize}
 <<#owner_is_federal_executive>>
-<<#display_owner>>
+<<^is_suborg>>
 \item \attachfile[appearance=false,mimetype=text/csv,icon=Paperclip,ucfilespec=certificates.csv]{certificates.csv} certificates.csv : Data collected about each certificate found that was issued for a domain known to belong to you.
 \item \attachfile[appearance=false,mimetype=text/csv,icon=Paperclip,ucfilespec=domains.csv]{domains.csv} domains.csv : A \gls{CSV} containing all the base domains we know belong to you.
-<</display_owner>>
+<</is_suborg>>
 <</owner_is_federal_executive>>
 \item \attachfile[appearance=false,mimetype=text/csv,icon=Paperclip,ucfilespec=findings.csv]{findings.csv} findings.csv : Detailed list of all \gls{vulnerability} findings for each \gls{IP} address and port.
   \item \attachfile[appearance=false,mimetype=text/csv,icon=Paperclip,ucfilespec=mitigated-vulnerabilities.csv]{mitigated-vulnerabilities.csv} mitigated-vulnerabilities.csv : List of vulnerabilities that were included on the last report, but were not detected in the latest scans.


### PR DESCRIPTION
Domains are associated with parent orgs, not suborgs, so there is never any ED 19-01 data for suborgs.  Instead we display slightly different language in that case.

I also took the opportunity to rewrite (with the help of @dav3r) the multiple cert count queries into a single aggregation query.  As a result, this pull request resolves #16.