### PR TITLE
Fix CybEx Cert Total Bugs

### DIFF
--- a/cyhy_report/cybex_scorecard/generate_cybex_scorecard.py
+++ b/cyhy_report/cybex_scorecard/generate_cybex_scorecard.py
@@ -994,10 +994,10 @@ class ScorecardGenerator(object):
                                          field_to_accumulate):
         self.__results['federal_totals']['cert-scan'][field_to_accumulate] += 1
 
-        if certificate['cfo_act_org'] is True:
+        if certificate['cfo_act_org']:
             self.__results['cfo_totals']['cert-scan'][field_to_accumulate] += 1
 
-        if certificate['non_cfo_act_org'] is True:
+        if certificate['non_cfo_act_org']:
             self.__results['non_cfo_totals']['cert-scan'][
                 field_to_accumulate] += 1
 


### PR DESCRIPTION
This PR fixes two bugs in the Cyber Exposure Scorecard:
- The Federal/CFO Act/Non-CFO Act totals were not being initialized to zero, so if no certificates were found in the database for one or more of our summary metrics ("New Certificates (Past 7 Days)", "New Certificates (Past 30 Days)", "New Certificates (Current Fiscal Year)", "Unexpired Certificates"), the PDF creation process would fail because there was a null value where there should have been a zero.
- Previously, when counting the total number of certs for Non-CFO Act orgs, we were not ensuring that the owner of a cert's subject was a member of the list of CybEx orgs. If an org was not a CFO Act org, it was assumed to be a CybEx Non-CFO Act org, when in fact, it could have been a non-CybEx Non-CFO Act org, thus (incorrectly) inflating the Non-CFO Act totals that we report on the CybEx Scorecard.

I also updated a comment to give more explanation about why the Federal/CFO Act/Non-CFO Act totals can be less than the sum of their member agency cert counts, since that can be a bit confusing.