### PR TITLE
Fix CybEx Scorecard bug with deltas of high severity vulnerabilities

### DIFF
--- a/cyhy_report/cybex_scorecard/generate_cybex_scorecard.py
+++ b/cyhy_report/cybex_scorecard/generate_cybex_scorecard.py
@@ -1545,7 +1545,7 @@ class ScorecardGenerator(object):
 
             # Calculate open_highs_delta_since_last_scorecard
             if self.__results[total_id]['vuln-scan']['metrics'].get(
-              'open_highs_delta_since_last_scorecard'):
+              'open_highs_on_previous_scorecard'):
                 self.__results[total_id]['vuln-scan']['metrics']['open_highs_delta_since_last_scorecard'] = self.__results[total_id]['vuln-scan']['metrics']['open_highs'] - self.__results[total_id]['vuln-scan']['metrics']['open_highs_on_previous_scorecard']
             else:
                 self.__results[total_id]['vuln-scan']['metrics']['open_highs_delta_since_last_scorecard'] = self.__results[total_id]['vuln-scan']['metrics']['open_highs']


### PR DESCRIPTION
This PR fixes a bug that was introduced in PR #24, where an incorrect variable name was used to determine whether or not the previous scorecard JSON had data for the total number of high severity vulns.  

This bug only affected the deltas in the FEDERAL GOVERNMENT TOTAL, “CFO ACT” AGENCIES TOTAL, and NON-“CFO ACT” AGENCIES TOTAL rows in the "BOD 15-01 Results by Agency" section.  It did not affect the deltas for individual agencies.