### PR TITLE
Only fail for sp!=reject for organizational domains

### DIFF
--- a/cyhy_report/cybex_scorecard/generate_cybex_scorecard.py
+++ b/cyhy_report/cybex_scorecard/generate_cybex_scorecard.py
@@ -818,7 +818,12 @@ class ScorecardGenerator(object):
                                                 {'$eq': ['$live', True]},
                                                 {'$eq': ['$valid_dmarc', True]},
                                                 {'$eq': ['$dmarc_policy', 'reject']},
-                                                {'$eq': ['$dmarc_subdomain_policy', 'reject']},
+                                                {
+                                                  '$or': [
+                                                      {'$eq': ['$is_base_domain', False]},
+                                                      {'$eq': ['$dmarc_subdomain_policy', 'reject']},
+                                                  ]
+                                                },
                                                 {'$eq': ['$dmarc_policy_percentage', 100]}
                                             ]
                                         },
@@ -892,7 +897,12 @@ class ScorecardGenerator(object):
                                                 {'$eq': ['$live', True]},
                                                 {'$eq': ['$valid_dmarc', True]},
                                                 {'$eq': ['$dmarc_policy', 'reject']},
-                                                {'$eq': ['$dmarc_subdomain_policy', 'reject']},
+                                                {
+                                                  '$or': [
+                                                      {'$eq': ['$is_base_domain', False]},
+                                                      {'$eq': ['$dmarc_subdomain_policy', 'reject']},
+                                                  ]
+                                                },
                                                 {'$eq': ['$dmarc_policy_percentage', 100]},
                                                 {'$eq': ['$has_bod1801_dmarc_rua_uri', True]}
                                             ]
@@ -910,7 +920,12 @@ class ScorecardGenerator(object):
                                                 {'$eq': ['$live', True]},
                                                 {'$eq': ['$valid_dmarc', True]},
                                                 {'$eq': ['$dmarc_policy', 'reject']},
-                                                {'$eq': ['$dmarc_subdomain_policy', 'reject']},
+                                                {
+                                                  '$or': [
+                                                      {'$eq': ['$is_base_domain', False]},
+                                                      {'$eq': ['$dmarc_subdomain_policy', 'reject']},
+                                                  ]
+                                                },
                                                 {'$eq': ['$dmarc_policy_percentage', 100]},
                                                 {'$eq': ['$has_bod1801_dmarc_rua_uri', True]},
                                                 {'$eq': ['$is_missing_starttls', False]},
@@ -1209,7 +1224,12 @@ class ScorecardGenerator(object):
                                                     ]
                                                 },
                                                 {'$eq': ['$dmarc_policy', 'reject']},
-                                                {'$eq': ['$dmarc_subdomain_policy', 'reject']},
+                                                {
+                                                  '$or': [
+                                                      {'$eq': ['$is_base_domain', False]},
+                                                      {'$eq': ['$dmarc_subdomain_policy', 'reject']},
+                                                  ]
+                                                },
                                                 {'$eq': ['$dmarc_policy_percentage', 100]}
                                             ]
                                         },
@@ -1297,7 +1317,12 @@ class ScorecardGenerator(object):
                                                             ]
                                                         },
                                                         {'$eq': ['$dmarc_policy', 'reject']},
-                                                        {'$eq': ['$dmarc_subdomain_policy', 'reject']},
+                                                        {
+                                                            '$or': [
+                                                                {'$eq': ['$is_base_domain', False]},
+                                                                {'$eq': ['$dmarc_subdomain_policy', 'reject']},
+                                                            ]
+                                                        },
                                                         {'$eq': ['$dmarc_policy_percentage', 100]}
                                                     ]
                                                 }
@@ -1349,7 +1374,12 @@ class ScorecardGenerator(object):
                                                     ]
                                                 },
                                                 {'$eq': ['$dmarc_policy', 'reject']},
-                                                {'$eq': ['$dmarc_subdomain_policy', 'reject']},
+                                                {
+                                                    '$or': [
+                                                        {'$eq': ['$is_base_domain', False]},
+                                                        {'$eq': ['$dmarc_subdomain_policy', 'reject']},
+                                                    ]
+                                                },
                                                 {'$eq': ['$dmarc_policy_percentage', 100]},
                                                 {'$eq': ['$has_bod1801_dmarc_rua_uri', True]}
                                             ]
@@ -1372,7 +1402,12 @@ class ScorecardGenerator(object):
                                                     ]
                                                 },
                                                 {'$eq': ['$dmarc_policy', 'reject']},
-                                                {'$eq': ['$dmarc_subdomain_policy', 'reject']},
+                                                {
+                                                    '$or': [
+                                                        {'$eq': ['$is_base_domain', False]},
+                                                        {'$eq': ['$dmarc_subdomain_policy', 'reject']},
+                                                    ]
+                                                },
                                                 {'$eq': ['$dmarc_policy_percentage', 100]},
                                                 {'$eq': ['$has_bod1801_dmarc_rua_uri', True]},
                                                 {'$eq': ['$is_missing_starttls', False]},
@@ -1390,7 +1425,12 @@ class ScorecardGenerator(object):
                                                                     ]
                                                                 },
                                                                 {'$eq': ['$dmarc_policy', 'reject']},
-                                                                {'$eq': ['$dmarc_subdomain_policy', 'reject']},
+                                                                {
+                                                                    '$or': [
+                                                                        {'$eq': ['$is_base_domain', False]},
+                                                                        {'$eq': ['$dmarc_subdomain_policy', 'reject']},
+                                                                    ]
+                                                                },
                                                                 {'$eq': ['$dmarc_policy_percentage', 100]}
                                                             ]
                                                         }
@@ -1552,7 +1592,12 @@ class ScorecardGenerator(object):
                                         '$and': [
                                             {'$eq': ['$dmarc_policy', 'reject']},
                                             {'$eq': ['$valid_dmarc', True]},
-                                            {'$eq': ['$dmarc_subdomain_policy', 'reject']},
+                                            {
+                                                '$or': [
+                                                    {'$eq': ['$is_base_domain', False]},
+                                                    {'$eq': ['$dmarc_subdomain_policy', 'reject']},
+                                                ]
+                                            },
                                             {'$eq': ['$dmarc_policy_percentage', 100]}
                                         ]
                                     },


### PR DESCRIPTION
According to [RFC7489](https://tools.ietf.org/html/rfc7489#section-6.3),
> "sp" will be ignored for DMARC records published on subdomains of Organizational Domains
due to the effect of the DMARC policy discovery mechanism

Therefore we have chosen not to penalize subdomains for `sp!=reject` when considering whether subdomains satisfy a DMARC subdomain policy of reject.  This issue was originally brought to light in NCATS JIRA ticket CYHYDEV-761.

See also cisagov/trustymail#116 and cisagov/trustymail_reporter#33.