### PR TITLE
Make the pandas version agree with ncats-webd

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         # "basemap >= 1.0.6",
         "matplotlib == 1.5.3",
         "numpy == 1.10.4",
-        "pandas == 0.19.1",
+        "pandas == 0.19.2",
         "python-dateutil >= 2.2",
         "netaddr >= 0.7.10",
         "pystache >= 0.5.3",


### PR DESCRIPTION
Otherwise [cisagov/ansible-role-cyhy-reports](https://github.com/cisagov/ansible-role-cyhy-reports) can't be idempotent because it has [cisagov/ansible-role-ncats-webd](https://github.com/cisagov/ansible-role-ncats-webd) as a dependency.  They will flip-flop pandas versions as one is installed and then the other.