### PR TITLE
Fix bug building CybEx org list 

### DIFF
--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -57,7 +57,7 @@ def build_cybex_org_list(db):
     ):
         cybex_org_ids.append(cybex_request["_id"])
         if cybex_request.get("children"):
-            cybex_org_ids += db.RequestDoc.get_all_descendants(cybex_request["_id"])
+            cybex_org_ids.extend(db.RequestDoc.get_all_descendants(cybex_request["_id"]))
     return cybex_org_ids
 
 


### PR DESCRIPTION
CybEx orgs with children were not being included in list of CybEx orgs, even though their children were.  This PR rectifies that situation.  I also made a very small performance improvement.