### PR TITLE
Bugfix: Vulnerable host count percentage change in first report

### DIFF
--- a/cyhy_report/customer/generate_report.py
+++ b/cyhy_report/customer/generate_report.py
@@ -1996,6 +1996,10 @@ class ReportGenerator(object):
         result['draft'] = self.__draft
         calc = dict() # calculated vaules for report
 
+        calc['vuln_host_count_pct_increase_flag'] = False
+        calc['vuln_host_count_pct_decrease_flag'] = False
+        calc['vuln_host_count_pct_flat_flag'] = False
+
         calc['no_history'] = self.__no_history
         if self.__no_history:
             ss1 = ss0
@@ -2004,16 +2008,12 @@ class ReportGenerator(object):
                 calc['unique_operating_systems_percent'] =\
                 calc['unique_services_percent'] =\
                 calc['unique_vulnerabilities_percent'] = '-'
-            calc['vuln_host_count_pct_no_change'] = True
-            calc['vuln_host_count_pct_increase'] = False
+            calc['vuln_host_count_pct_flat_flag'] = True
+            calc['vuln_host_count_pct_change_int'] = 0
         else:
             ss1 = self.__snapshots[1]
             calc['host_count_percent'] = self.__percent_change(ss1['host_count'], ss0['host_count'])
             calc['vulnerable_host_count_percent'] = self.__percent_change(ss1['vulnerable_host_count'], ss0['vulnerable_host_count'])
-
-            calc['vuln_host_count_pct_increase_flag'] = False
-            calc['vuln_host_count_pct_decrease_flag'] = False
-            calc['vuln_host_count_pct_flat_flag'] = False
 
             if calc['vulnerable_host_count_percent'] == '-':
                 # See __percent_change() for how/why this can happen


### PR DESCRIPTION
This PR corrects a bug that reared its ugly head today when generating reports for orgs with only a single snapshot in the database (i.e. this was the first report ever created for that org).  Not only was an incorrect flag name being used, but I also failed to set the integer value of the percent change (`vuln_host_count_pct_change_int`) to zero.  Both of those issues are corrected here.

I manually tested the fix on every report that failed in this morning's weekly report run and every report was successfully generated after I made this code change. 