### PR TITLE
Get Rid of Unplanned Blank Page in CyHy Report

### DIFF
--- a/cyhy_report/customer/report.mustache
+++ b/cyhy_report/customer/report.mustache
@@ -748,7 +748,7 @@ As you review the report, you may have additional questions. Check out the answe
   \end{minipage}  % END: POTENTIALLY RISKY OPEN SERVICES
 
   % Blue triangle at bottom right corner of page
-  \vspace*{-12.2mm}  % VERY IMPORTANT: If layout changes above result in vertical spacing differences, this vspace amount will need to be adjusted; this may not be obvious in every case, but if you end up with a blank page before the Report Card page, this is a good place to start
+  \vspace*{-12.4mm}  % VERY IMPORTANT: If layout changes above result in vertical spacing differences, this vspace amount will need to be adjusted; this may not be obvious in every case, but if you end up with a blank page before the Report Card page, this is a good place to start.  Also note that since we are right at the edge of overflowing a page, it's possible that LaTeX engines on different platforms can produce slightly different results.  Don't forget to review the final product that is generated on your Production system.
   \hspace*{125mm}
   \begin{tikzpicture}
     \draw[color=rc-dark-blue, fill=rc-dark-blue](0mm,0mm) -- (90mm,0mm) -- (90mm,20mm) -- cycle;


### PR DESCRIPTION
This small PR is to modify the vertical spacing (by 0.2mm!) in the CyHy report to prevent a blank page from being rendered when the report is generated on a Debian host.

During [CYHYDEV-777](https://jira.ncats.cyber.dhs.gov/browse/CYHYDEV-777), I tested and validated the reports by generating them on my development system running Mac OS X.  I encountered the aforementioned blank page during my testing and I fixed it, at least when the reports were generated on my Mac.  I didn't count on there being any notable differences between my Mac vs. on our Production Debian host and that turned out to be a mistake.

I am not sure exactly what accounts for the ever-so-slight difference in rendering, but I did indeed test that when a report is generated on our Debian host with this code change, the blank page is eliminated.

For posterity, here are the `xelatex` versions on my Mac and our Production Debian host:

**Mac**:
```❱ xelatex --version
XeTeX 3.14159265-2.6-0.99996 (TeX Live 2016)
kpathsea version 6.2.2
Copyright 2016 SIL International, Jonathan Kew and Khaled Hosny.
There is NO warranty.  Redistribution of this software is
covered by the terms of both the XeTeX copyright and
the Lesser GNU General Public License.
For more information about these matters, see the file
named COPYING and the XeTeX source.
Primary author of XeTeX: Jonathan Kew.
Compiled with ICU version 57.1; using 57.1
Compiled with zlib version 1.2.8; using 1.2.8
Compiled with FreeType2 version 2.6.3; using 2.6.3
Compiled with Graphite2 version 1.3.8; using 1.3.8
Compiled with HarfBuzz version 1.2.6; using 1.2.6
Compiled with libpng version 1.6.21; using 1.6.21
Compiled with poppler version 0.42.0
Using Mac OS X Core Text and Cocoa frameworks
```

**Debian:**
```$ xelatex --version
XeTeX 3.14159265-2.6-0.99996 (TeX Live 2016/Debian)
kpathsea version 6.2.2
Copyright 2016 SIL International, Jonathan Kew and Khaled Hosny.
There is NO warranty.  Redistribution of this software is
covered by the terms of both the XeTeX copyright and
the Lesser GNU General Public License.
For more information about these matters, see the file
named COPYING and the XeTeX source.
Primary author of XeTeX: Jonathan Kew.
Compiled with ICU version 57.1; using 57.1
Compiled with zlib version 1.2.8; using 1.2.8
Compiled with FreeType2 version 2.6.3; using 2.6.3
Compiled with Graphite2 version 1.3.10; using 1.3.10
Compiled with HarfBuzz version 1.4.2; using 1.4.2
Compiled with libpng version 1.6.28; using 1.6.28
Compiled with poppler version 0.48.0
Compiled with fontconfig version 2.11.0; using 2.11.0
```