### PR TITLE
Bugfix: Swap "Resolved" and "New" Vulnerability Counts in Bubble Chart

### DIFF
--- a/cyhy_report/customer/generate_report.py
+++ b/cyhy_report/customer/generate_report.py
@@ -972,8 +972,8 @@ class ReportGenerator(object):
             vuln_data.append(
                 (
                     self.__snapshots[0]['vulnerabilities'][severity],
-                    self.__results['new_vulnerability_counts'][severity],
                     self.__results['resolved_vulnerability_counts'][severity],
+                    self.__results['new_vulnerability_counts'][severity],
                 )
             )
             active_vulns[severity] = self.__snapshots[0]['vulnerabilities'][severity]


### PR DESCRIPTION
One of our stakeholders received their CyHy report and noticed that we incorrectly displayed swapped values for the number of "Resolved" and "New" vulnerabilities in the new Report Card bubble chart (from #42).

This small, but important PR corrects this situation.

I tested this change by generating two reports and verifying that the numbers are now being correctly displayed.