### PR TITLE
Eliminate duplicate CyHy notifications

### DIFF
--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -49,16 +49,16 @@ def build_cyhy_org_list(db):
     This is the list of CyHy organization IDs (and their descendants) that
     receive CyHy reports.
     """
-    cyhy_org_ids = list()
+    cyhy_org_ids = set()  # Use a set here to avoid duplicates
     for cyhy_request in list(
         db.RequestDoc.collection.find(
             {"report_types": "CYHY"}, {"_id": 1, "children": 1}
         ).sort([("_id", 1)])
     ):
-        cyhy_org_ids.append(cyhy_request["_id"])
+        cyhy_org_ids.add(cyhy_request["_id"])
         if cyhy_request.get("children"):
-            cyhy_org_ids.extend(db.RequestDoc.get_all_descendants(cyhy_request["_id"]))
-    return cyhy_org_ids
+            cyhy_org_ids.update(db.RequestDoc.get_all_descendants(cyhy_request["_id"]))
+    return list(cyhy_org_ids)
 
 
 def generate_notification_pdfs(db, org_ids, master_report_key):


### PR DESCRIPTION
This morning, I checked the set of notifications that were created in `prod-a` (since the code for [CYHYDEV-779](https://jira.ncats.cyber.dhs.gov/browse/CYHYDEV-779) and [CYHYDEV-781](https://jira.ncats.cyber.dhs.gov/browse/CYHYDEV-781) went live yesterday) and I noticed that a couple of CyHy orgs had 2 notification PDFs generated.  I was worried that these orgs each received two (duplicate) notification emails, but thankfully the [cyhy-mailer code is smart enough](https://github.com/cisagov/cyhy-mailer/blob/develop/cyhy/mailer/cli.py#L927-L939) to prevent that from happening.

Still, this situation should be remedied.  A quick review of the code revealed that we were using a list to store the IDs of CyHy report recipients, then adding children of report recipients to that list.  Since it is possible for a child of a report recipient to also be a CyHy report recipient themselves, it is possible for an org's ID to end up in that list twice, which would result in two notification PDFs being generated.

This PR remedies that issue by storing the CyHy org IDs in a set instead of a list, so duplicates are not possible.

I tested these code changes locally by running them via our old [`sandbox.py`](https://github.com/jsf9k/cyhy-oneoffs/blob/develop/sandbox.py) script and everything worked as expected.
