### PR TITLE
Create snapshots for grouping nodes required by third-party reports

### DIFF
--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -574,7 +574,8 @@ def create_third_party_snapshots(db, cyhy_db_section, third_party_report_ids):
                 # remove them from list of third_party_report_ids so that we
                 # don't attempt to create them below.
                 for org_id in tp_dependence_map[grouping_node_id]:
-                    failed_tp_snaps.append(org_id)
+                    if org_id not in failed_tp_snaps:
+                        failed_tp_snaps.append(org_id)
                     if org_id in third_party_report_ids:
                         third_party_report_ids.remove(org_id)
 

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -526,35 +526,19 @@ def create_third_party_snapshots(db, cyhy_db_section, third_party_report_ids):
     failed_tp_snaps = list()
 
     for third_party_id in third_party_report_ids:
-        snapshot_start_time = time.time()
-        snapshot_process = subprocess.Popen(
-            [
-                "cyhy-snapshot",
-                "--section",
-                cyhy_db_section,
-                "create",
-                "--use-only-existing-snapshots",
-                third_party_id,
-            ],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
         )
-        # Confirm the snapshot
-        data, err = snapshot_process.communicate("yes")
 
-        snapshot_duration = time.time() - snapshot_start_time
 
-        if snapshot_process.returncode == 0:
+    logging.info("Creating third-party snapshots...")
+    for third_party_id in third_party_report_ids:
+        snapshot_rc = create_snapshot(
+            db, cyhy_db_section, third_party_id, use_only_existing_snapshots=True
+        )
+
+        if snapshot_rc == 0:
             successful_tp_snaps.append(third_party_id)
-            logging.info(
-                "Successfully created third-party snapshot:"
-                " {} ({:.2f} s)".format(third_party_id, round(snapshot_duration, 2))
-            )
         else:
             failed_tp_snaps.append(third_party_id)
-            logging.error("Third-party snapshot failed: {}".format(third_party_id))
-            logging.error("Stderr failure detail: {} {}".format(data, err))
 
     logging.info(
         "Time to create all third-party snapshots:"

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -487,6 +487,39 @@ def resume_commander(db, pause_doc_id):
     return True
 
 
+def create_snapshot(db, cyhy_db_section, org_id, use_only_existing_snapshots):
+    snapshot_start_time = time.time()
+
+    snapshot_command = ["cyhy-snapshot", "--section", cyhy_db_section, "create"]
+
+    if use_only_existing_snapshots:
+        snapshot_command.extend(["--use-only-existing-snapshots", org_id])
+    else:
+        snapshot_command.append(org_id)
+
+    snapshot_process = subprocess.Popen(
+        snapshot_command,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    # Confirm the snapshot creation
+    data, err = snapshot_process.communicate("yes")
+
+    snapshot_duration = time.time() - snapshot_start_time
+
+    if snapshot_process.returncode == 0:
+        logging.info(
+            "Successfully created snapshot:"
+            " {} ({:.2f} s)".format(org_id, round(snapshot_duration, 2))
+        )
+    else:
+        logging.error("Snapshot creation failed: %s", org_id)
+        logging.error("Stderr failure detail: %s %s", data, err)
+    return snapshot_process.returncode
+
+
 def create_third_party_snapshots(db, cyhy_db_section, third_party_report_ids):
     all_tps_start_time = time.time()
     successful_tp_snaps = list()


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR updates `create_third_party_snapshots()` so that a fresh snapshot creation is always attempted (using the --use-only-existing-snapshots flag) for all grouping nodes that are descendants of third-party report recipients, prior to generating their reports.

Resolves #52.
<!--- Describe your changes in detail -->

## 💭 Motivation and Context

As stated in #52:

> It is possible to set up an organization in CyHy as a ["third-party report recipient"](https://github.com/cisagov/cyhy-reports/pull/40). Recently, there has been a request to generate a third-party report that includes a CyHy "grouping node". A "grouping node" is simply a RequestDoc that is used as a parent/child node in our database hierarchy, but does not represent an actual organization. For example, there are grouping nodes for each Critical Infrastructure sector containing the CyHy organizations in each sector.
> 
> The bug occurs in the [`create_third_party_snapshots()` function in `extras/create_snapshots_reports_scorecard.py`](https://github.com/cisagov/cyhy-reports/blob/develop/extras/create_snapshots_reports_scorecard.py#L490). If a third-party report recipient contains a CyHy grouping node, we don't currently generate a fresh snapshot for the grouping node.
> 
> If that grouping node snapshot doesn't exist, `create_third_party_snapshots()` will fail to create the snapshot for the third-party report recipient and thus no third-party report can be generated.
> 
> Even more fiendishly, if a latest snapshot does exist for that grouping node (even if it's quite outdated), it will be used and the report will contain the outdated data from that snapshot.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
I tested various pieces of these code changes in isolation to ensure they worked as expected.

For a more realistic test, I created several dummy orgs with a dummy report type (`TEST_TP`) and uploaded them to the database.  Then, I temporarily modified `create_snapshots_reports_scorecard.py` so that it only selected orgs with the `TEST_TP` report type and generated snapshots for them.  

My test ran successfully- all expected snapshots were created and the expected failure of one of the grouping node snapshots was handled properly.

When finished, I deleted all of the snapshots generated by my test and removed my dummy orgs from the database.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
