### PR TITLE
Correctly sort top services table in CyHy report

### DIFF
--- a/cyhy_report/customer/generate_report.py
+++ b/cyhy_report/customer/generate_report.py
@@ -1815,11 +1815,11 @@ class ReportGenerator(object):
         df = DataFrame.from_dict(ss0["services"], orient="index")
         if len(df) > 0:
             df = df.reset_index().rename(columns={"index": "service_name", 0: "count"})
+            df.sort_values(by="count", ascending=False, inplace=True)
             df["percent"] = df["count"] / float(np.sum(df["count"])) * 100
             other_count = np.sum(df[5:]["count"])
             other_percent = np.sum(df[5:]["percent"])
             df = df[:5]  # trim to top 5
-            df.sort_values(by="count", ascending=False, inplace=True)
             if other_count > 0:
                 df_other = DataFrame(
                     {


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR fixes a bug that was causing the "Top Services Detected" table in the CyHy report to display incorrect results for the top 5 most-detected services in the recipient organization.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
In the code that generates this table, the top 5 most-detected services were being selected **before** the data was sorted by number of detections, hence the incorrect (essentially random) results.  The small code change in this PR ensures that the data is sorted first, then the top 5 most-detected services can be correctly reported.

Looking at the commit history of this code, this bug has apparently been around for at least 2 years- it is a bit surprising that no report users have mentioned it by now.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
I verified that reports are generated successfully and the "Top Services Detected" table now is correct.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
