### PR TITLE
Parallelize snapshot creation

### DIFF
--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
-"""
+"""Generate the weekly Cyber Exposure scorecard and all CyHy reports.
+
 Usage:
   create_snapshots_reports_scorecard.py [options] CYHY_DB_SECTION SCAN_DB_SECTION
-
-Generate the weekly cybex scorecard and all the weekly persistent reports.
 
 Options:
   -h, --help            show this help message and exit

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -655,6 +655,7 @@ def create_third_party_snapshots(db, cyhy_db_section, third_party_report_ids):
                     if org_id in third_party_report_ids:
                         third_party_report_ids.remove(org_id)
 
+    # TODO Create third-party snapshots in threads
     logging.info("Creating third-party snapshots...")
     for third_party_id in third_party_report_ids:
         snapshot_rc = create_snapshot(

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -956,24 +956,42 @@ def main():
                 "Number of snapshots generated: %d", len(successful_snapshots),
             )
             logging.info(
+                "  Third-party snapshots generated: %d", len(successful_tp_snaps),
+            )
+            logging.info(
                 "Number of snapshots failed: %d", len(failed_snapshots),
+            )
+            logging.info(
+                "  Third-party snapshots failed: %d", len(failed_tp_snaps),
             )
             if failed_snapshots:
                 logging.error("Failed snapshots:")
                 for i in failed_snapshots:
-                    logging.error(i)
+                    if i in failed_tp_snaps:
+                        logging.error("%s (third-party)", i)
+                    else:
+                        logging.error(i)
 
         logging.info(
             "Number of reports generated: %d",
             len(successful_reports + successful_tp_reports),
         )
         logging.info(
+            "  Third-party reports generated: %d", len(successful_tp_reports),
+        )
+        logging.info(
             "Number of reports failed: %d", len(failed_reports + failed_tp_reports)
+        )
+        logging.info(
+            "  Third-party reports failed: %d", len(failed_tp_reports),
         )
         if failed_reports or failed_tp_reports:
             logging.info("Failed reports:")
             for i in failed_reports + failed_tp_reports:
-                logging.info(i)
+                if i in failed_tp_reports:
+                    logging.error("%s (third-party)", i)
+                else:
+                    logging.error(i)
 
         logging.info("Total time: %.2f minutes", (time.time() - start_time) / 60)
         logging.info("END\n\n")

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -379,7 +379,7 @@ def chunks(l, n):
 def create_reports(customer_list, cyhy_db_section, scan_db_section, use_docker, nolog):
     for i in customer_list:
         report_time = time.time()
-        logging.info("%s Starting report for: %s", threading.current_thread().name, i)
+        logging.info("[%s] Starting report for: %s", threading.current_thread().name, i)
         if use_docker == 1:
             if nolog:
                 p = subprocess.Popen(
@@ -470,7 +470,7 @@ def create_reports(customer_list, cyhy_db_section, scan_db_section, use_docker, 
         return_code = p.returncode
         if return_code == 0:
             logging.info(
-                "%s Successful report generated: %s (%.2f s)",
+                "[%s] Successful report generated: %s (%.2f s)",
                 threading.current_thread().name,
                 i,
                 round(report_time, 2),
@@ -478,10 +478,12 @@ def create_reports(customer_list, cyhy_db_section, scan_db_section, use_docker, 
             successful_reports.append(i)
         else:
             logging.info(
-                "%s Failure to generate report: %s", threading.current_thread().name, i
+                "[%s] Failure to generate report: %s",
+                threading.current_thread().name,
+                i,
             )
             logging.info(
-                "%s Stderr report detail: %s%s",
+                "[%s] Stderr report detail: %s%s",
                 threading.current_thread().name,
                 data,
                 err,
@@ -492,9 +494,10 @@ def create_reports(customer_list, cyhy_db_section, scan_db_section, use_docker, 
 def gen_weekly_reports(
     db, successful_snaps, cyhy_db_section, scan_db_section, use_docker, nolog
 ):
+    # TODO Clean this function up and make it similar to generate_weekly_snapshots()
     os.chdir(os.path.join(WEEKLY_REPORT_BASE_DIR, CYHY_REPORT_DIR))
-    start = time.time()
-    # Create a list that from the results of the function chunks:
+    start_time = time.time()
+    # Create a list from the results of the function chunks
     threads = []
     thread_list = list(
         chunks(
@@ -517,10 +520,10 @@ def gen_weekly_reports(
         t.join()
     report_durations.sort(key=lambda tup: tup[1], reverse=True)
     logging.info("Longest Reports:")
-        logging.info("%s: %s seconds", i[0], str(round(i[1], 1)))
     for i in report_durations[:10]:
+        logging.info("%s: %.1f seconds", i[0], i[1])
     logging.info(
-        "Time to complete reports: %.2f minutes", (round(time.time() - start, 1) / 60)
+        "Time to complete reports: %.2f minutes", (time.time() - start_time) / 60
     )
 
     # Create a symlink to the latest reports.  This is for the

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -355,14 +355,14 @@ def generate_weekly_snapshots(db, cyhy_db_section):
     # Wait until each thread terminates
     for snapshot_thread in snapshot_threads:
         snapshot_thread.join()
+    logging.info(
+        "Time to complete snapshots: %.2f minutes", (time.time() - start_time) / 60
+    )
 
     snapshot_durations.sort(key=lambda tup: tup[1], reverse=True)
     logging.info("Longest Snapshots:")
     for i in snapshot_durations[:10]:
         logging.info("%s: %.1f seconds", i[0], i[1])
-    logging.info(
-        "Time to complete snapshots: %.2f minutes", (time.time() - start_time) / 60
-    )
 
     reports_to_generate = set(reports_to_generate) - set(failed_snapshots)
     return sorted(list(reports_to_generate))

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -349,7 +349,7 @@ def generate_weekly_snapshots(db, cyhy_db_section):
             )
             snapshot_threads.append(snapshot_thread)
             snapshot_thread.start()
-        except:
+        except Exception:
             print("Error: Unable to start snapshot thread for %s", orgs)
 
     # Wait until each thread terminates

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -38,6 +38,7 @@ current_time = util.utcnow()
 LOGGING_LEVEL = logging.INFO
 LOG_FILE = "snapshots_reports_scorecard_automation.log"
 REPORT_THREADS = 16
+SNAPSHOT_THREADS = 16
 
 NCATS_DHUB_URL = "dhub.ncats.cyber.dhs.gov:5001"
 NCATS_WEB_URL = "web.data.ncats.cyber.dhs.gov"
@@ -53,10 +54,24 @@ CYHY_REPORT_DIR = os.path.join(
 CRITICAL_SEVERITY = 4
 HIGH_SEVERITY = 3
 
-# Global variables for threading
+# Global variables and their associated thread locks
+successful_snapshots = list()
+ss_lock = threading.Lock()
+
+failed_snapshots = list()
+fs_lock = threading.Lock()
+
+snapshot_durations = list()
+sd_lock = threading.Lock()
+
 successful_reports = list()
+sr_lock = threading.Lock()
+
 failed_reports = list()
+fr_lock = threading.Lock()
+
 report_durations = list()
+rd_lock = threading.Lock()
 
 
 def create_subdirectories():

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -495,6 +495,7 @@ def gen_weekly_reports(
     db, successful_snaps, cyhy_db_section, scan_db_section, use_docker, nolog
 ):
     # TODO Clean this function up and make it similar to generate_weekly_snapshots()
+    # See https://github.com/cisagov/cyhy-reports/issues/59
     os.chdir(os.path.join(WEEKLY_REPORT_BASE_DIR, CYHY_REPORT_DIR))
     start_time = time.time()
     # Create a list from the results of the function chunks
@@ -656,6 +657,7 @@ def create_third_party_snapshots(db, cyhy_db_section, third_party_report_ids):
                         third_party_report_ids.remove(org_id)
 
     # TODO Create third-party snapshots in threads
+    # See https://github.com/cisagov/cyhy-reports/issues/60
     logging.info("Creating third-party snapshots...")
     for third_party_id in third_party_report_ids:
         snapshot_rc = create_snapshot(

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -219,7 +219,7 @@ def create_weekly_snapshots(db, cyhy_db_section):
     # request_list = ['49ers', 'USAID', 'Hawaii', 'DAS-BEST', 'COC', 'DHS', 'COLA', 'COA', 'COGG']
 
     for i in request_list:
-        # If the customer is in the decsendant org list then don't snap, add to successful
+        # If the customer is in the descendant org list then don't snap, add to successful
         # Assume that parent orgs will always be snapped first
         if i in successful_descendant_snaps:
             successful_snaps.append(i)

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -260,9 +260,9 @@ def create_snapshot(db, cyhy_db_section, org_id, use_only_existing_snapshots):
     snapshot_command = ["cyhy-snapshot", "--section", cyhy_db_section, "create"]
 
     if use_only_existing_snapshots:
-        snapshot_command.extend(["--use-only-existing-snapshots", org_id])
-    else:
-        snapshot_command.append(org_id)
+        snapshot_command.append("--use-only-existing-snapshots")
+
+    snapshot_command.append(org_id)
 
     snapshot_process = subprocess.Popen(
         snapshot_command,

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -312,7 +312,7 @@ def create_snapshot(db, cyhy_db_section, org_id, use_only_existing_snapshots):
     return snapshot_process.returncode
 
 
-def create_snapshots(org_list, db, cyhy_db_section):
+def create_snapshots_from_list(org_list, db, cyhy_db_section):
     """Create a snapshot for each organization in a list."""
     for org_id in org_list:
         logging.info(
@@ -345,7 +345,7 @@ def generate_weekly_snapshots(db, cyhy_db_section):
     for orgs in snapshots_to_generate:
         try:
             snapshot_thread = threading.Thread(
-                target=create_snapshots, args=(orgs, db, cyhy_db_section),
+                target=create_snapshots_from_list, args=(orgs, db, cyhy_db_section),
             )
             snapshot_threads.append(snapshot_thread)
             snapshot_thread.start()

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -350,7 +350,7 @@ def generate_weekly_snapshots(db, cyhy_db_section):
             snapshot_threads.append(snapshot_thread)
             snapshot_thread.start()
         except Exception:
-            print("Error: Unable to start snapshot thread for %s", orgs)
+            logging.error("Unable to start snapshot thread for %s", orgs)
 
     # Wait until each thread terminates
     for snapshot_thread in snapshot_threads:

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -214,8 +214,6 @@ def create_weekly_snapshots(db, cyhy_db_section):
             )
         ]
     )
-    # request_list = ['49ers', 'USAID', 'Hawaii', 'DAS-BEST', 'COC', 'DHS', 'COLA', 'COA', 'COGG', 'AGRS', 'FEC', 'FHFA', 'FMC', 'LPG', 'MSFG', 'OGE', 'PRC', 'SJI', 'USAB', 'VB']
-    # request_list = ['49ers', 'USAID', 'Hawaii', 'DAS-BEST', 'COC', 'DHS', 'COLA', 'COA', 'COGG']
 
     for i in request_list:
         # If the customer is in the descendant org list then don't snap, add to successful
@@ -832,8 +830,6 @@ def main():
                     )
                 ]
             )
-            # For testing:
-            # success_snaps = ['49ers', 'USAID', 'Hawaii', 'DAS-BEST', 'COC', 'DHS', 'SDSD', 'COLA', 'COA', 'COGG', 'AGRS', 'FEC', 'FHFA', 'FMC', 'LPG', 'MSFG', 'OGE', 'PRC', 'SJI', 'USAB', 'VB']
         else:
             success_snaps, failed_snaps = create_weekly_snapshots(db, cyhy_db_section)
 
@@ -915,10 +911,6 @@ def main():
 
         logging.info("Total time: %.2f minutes", (round(time.time() - start, 1) / 60))
         logging.info("END\n\n")
-
-        # logging.info('Kicking off the emailing of reports...')
-        # subprocess.call('/var/cyhy/cyhy-mailer/start.sh')
-        # logging.info('Done.')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
This PR modifies the [weekly reporting script](https://github.com/cisagov/cyhy-reports/blob/develop/extras/create_snapshots_reports_scorecard.py) so that snapshot creation is multithreaded, instead of single-threaded.

While I was making changes to this script, I took the opportunity to clean up some function names, variable names, comments, and logging statements to make them clearer and more consistent (https://github.com/cisagov/cyhy-reports/commit/69795cc48585b7bca5b9b6a0d0dbc6a12b23da6b, https://github.com/cisagov/cyhy-reports/commit/fd426e517a6cc034ccd097990136511772960d48, https://github.com/cisagov/cyhy-reports/commit/d208d94dfa22688a48ac4885654e01716edc704f).  I also removed some old testing code that had been commented-out, but is no longer needed (https://github.com/cisagov/cyhy-reports/commit/70ea90c3b85c19005190a3861ef29a2470589775).

Resolves #58.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and Context ##
From #58:
> Creating snapshots is the biggest chunk of our weekly reporting time (about 700 minutes out of 850 minutes total; that's over 80% of the total time and climbing with each new report recipient we add). By creating multiple snapshots at once, we should be able to significantly reduce the total time it takes to create snapshots, just like we have done with report creation.
> 
> Since we have to pause the commander while snapshots and reports are generated, shorter reporting time means more weekly uptime for CyHy processing.

This PR starts us off with 16 threads for snapshot creation, since that is how many we currently use for report creation.  That number can be increased or decreased in Production after we observe how long the threaded snapshot creation process takes and if there are any database performance issues.  

Related, we may be able to increase the number of report-creation threads and reduce the time it takes to make the reports (currently 133 minutes), since the initial number of 16 threads predates our AWS infrastructure (we currently use an instance with 8 cores to generate reports).

Note that third-party snapshot creation (which must occur after "regular" snapshot creation) has not moved to threads yet.  Those third-party snapshots are created relatively quickly (less than 6 minutes currently), so we won't save all that much time by creating them in parallel.  Still, I added [a TODO to do that eventually](https://github.com/cisagov/cyhy-reports/commit/ec9525f26d8114edf2a05da8edaa00e9ba1645f4).

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I tested these changes on my local system using the set of Production organizations, except I neutered the code so that no actual snapshots or reports were generated.  

Once I was satisfied with that testing, I created a set of 37 dummy orgs (32 "regular" orgs and 5 "third-party reporting" orgs) and imported them to a test environment (thanks @mcdonnnj for letting me use your environment).  I then ran the entire script (well, I commented out a couple of unrelated bits of code that would've required more test environment setup than I was willing to do) and confirmed that the new multithreaded code successfully generated snapshots for the regular orgs and the third-party snapshots were also generated successfully (non-threaded, but using code that was modified in this PR).

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] _All_ future TODOs are captured in issues, which are referenced in code comments.
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
