### PR TITLE
Adjust thread counts for Production

### DIFF
--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -37,8 +37,8 @@ current_time = util.utcnow()
 
 LOGGING_LEVEL = logging.INFO
 LOG_FILE = "snapshots_reports_scorecard_automation.log"
-REPORT_THREADS = 16
-SNAPSHOT_THREADS = 16
+REPORT_THREADS = 24
+SNAPSHOT_THREADS = 32
 
 NCATS_DHUB_URL = "dhub.ncats.cyber.dhs.gov:5001"
 NCATS_WEB_URL = "web.data.ncats.cyber.dhs.gov"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
This PR increases the number of threads used to generate:
* snapshots from 16 to 32
* reports from 16 to 24

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
We want the weekly reporting process to complete as quickly as possible and without any failures.  Increasing the thread counts is an easy way to reduce the overall duration of this process.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
We tested various thread counts in Production over the past few weeks and these are our optimal settings.

We observed some report generation failures when we attempted to use 32 threads, so we settled on 24.

There was a minor performance improvement in snapshot generation when going from 24 to 32 threads, so we have decided to not increase the thread count any further.
<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
