### PR TITLE
Decrease report generation threads in Production

### DIFF
--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -37,7 +37,7 @@ current_time = util.utcnow()
 
 LOGGING_LEVEL = logging.INFO
 LOG_FILE = "snapshots_reports_scorecard_automation.log"
-REPORT_THREADS = 24
+REPORT_THREADS = 20
 SNAPSHOT_THREADS = 32
 
 NCATS_DHUB_URL = "dhub.ncats.cyber.dhs.gov:5001"


### PR DESCRIPTION
Reduces thread count for report generation to hopefully avoid repeats of "cannot allocate memory" as in https://github.com/cisagov/cyhy-reports/issues/64

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

Reduces thread count from `24` to `20` to prevent threads from being unable to allocate memory.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

During report generation last weekend, we got an `OSError` because the environment couldn't allocate memory to generate a report. The issue is documented at https://github.com/cisagov/cyhy-reports/issues/64

If we continue to see this error, we can go back down to 16 threads for report generation which we've successfully run before.

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
This change is already made on `reporter` so we're putting the `blocked` label on for now and will test the fix next weekend during report generation.

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [x] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
