### PR TITLE
Generate "urgent tickets" CSVs

### DIFF
--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -760,20 +760,12 @@ def pull_cybex_ticket_csvs(db):
         shutil.copy(path, latest_path)
 
     save_csv(
-        "cybex_open_tickets_critical_{}.csv".format(today),
-        cybex_queries.csv_get_open_tickets(db, CRITICAL_SEVERITY),
+        "cybex_open_tickets_urgent_{}.csv".format(today),
+        cybex_queries.csv_get_open_tickets(db, "urgent"),
     )
     save_csv(
-        "cybex_closed_tickets_critical_{}.csv".format(today),
-        cybex_queries.csv_get_closed_tickets(db, CRITICAL_SEVERITY),
-    )
-    save_csv(
-        "cybex_open_tickets_high_{}.csv".format(today),
-        cybex_queries.csv_get_open_tickets(db, HIGH_SEVERITY),
-    )
-    save_csv(
-        "cybex_closed_tickets_high_{}.csv".format(today),
-        cybex_queries.csv_get_closed_tickets(db, HIGH_SEVERITY),
+        "cybex_closed_tickets_urgent_{}.csv".format(today),
+        cybex_queries.csv_get_closed_tickets(db, "urgent"),
     )
 
 

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -51,9 +51,6 @@ CYHY_REPORT_DIR = os.path.join(
     "report_archive", "reports{}".format(current_time.strftime("%Y%m%d"))
 )
 
-CRITICAL_SEVERITY = 4
-HIGH_SEVERITY = 3
-
 # Global variables and their associated thread locks
 successful_snapshots = list()
 ss_lock = threading.Lock()


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR modifies the `create_snapshots_reports_scorecard.py` script so that it produces two new CSVs:
* `cybex_open_tickets_urgent_YYYYMMDD.csv`
* `cybex_closed_tickets_urgent_YYYYMMDD.csv`

The two CSVs above replace these 4 previously-created CSVs:
* `cybex_open_tickets_critical_YYYYMMDD.csv`
* `cybex_closed_tickets_critical_YYYYMMDD.csv`
* `cybex_open_tickets_high_YYYYMMDD.csv`
* `cybex_closed_tickets_high_YYYYMMDD.csv`

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

* This PR resolves https://github.com/cisagov/cyhy-system/issues/49
* This PR covers part of the work requested in https://github.com/cisagov/cyhy-system/issues/34
* This PR is dependent on the changes in https://github.com/cisagov/ncats-webd/pull/27

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I tested these changes by commenting out most of the code in `create_snapshots_reports_scorecard.py`, except for the lines related to creating these new CSVs.  I verified that running that code resulted in the creation of the two new "urgent tickets" CSVs, as expected.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.