### PR TITLE
Bugfixes after BOD 22-01 deployment

### DIFF
--- a/cyhy_report/customer/generate_report.py
+++ b/cyhy_report/customer/generate_report.py
@@ -2172,11 +2172,11 @@ class ReportGenerator(object):
         # Calculate Known Exploited Vulnerability (KEV) Counts
         # Active KEV counts and find maximum active KEV age
         active_kev_counts = Series([0, 0, 0, 0])
+        kev_max_age = 0
         if len(df0):
             # Filter for KEV tickets in df0 (open tickets)
             df_active_kev = df0[df0["kev"] == True]
 
-            kev_max_age = 0
             if len(df_active_kev):
                 kev_max_age = df_active_kev["age"].max()
                 # Get count of tickets with each severity

--- a/cyhy_report/customer/generate_report.py
+++ b/cyhy_report/customer/generate_report.py
@@ -485,7 +485,9 @@ class ReportGenerator(object):
         return tickets
 
     def __load_ticket_age_data(self, start_date, severity, graph_bucket_cutoff_days):
-        tomorrow = self.__generated_time + datetime.timedelta(days=1)
+        tomorrow = pd.to_datetime(
+            self.__generated_time + datetime.timedelta(days=1), utc=True
+        )
         days_to_graph = pd.to_datetime(
             pd.date_range(start_date, self.__generated_time), utc=True
         )
@@ -507,10 +509,8 @@ class ReportGenerator(object):
         tix = list(tix)
         if len(tix):
             df = DataFrame(tix)
-            df.time_closed = df.time_closed.fillna(
-                tomorrow, downcast="infer"
-            )  # for accounting purposes, say all open tix will close tomorrow
-            # downcast='infer' needed above to avoid "NotImplementedError: reshaping is not supported for Index objects" (pandas 0.19.1)
+            # for accounting purposes, say all open tix will close tomorrow
+            df.time_closed = df.time_closed.fillna(tomorrow)
             df.time_closed = pd.to_datetime(
                 df.time_closed, utc=True
             )  # convert times to datetime64
@@ -2024,9 +2024,8 @@ class ReportGenerator(object):
             # Without the fillna steps below, groupby will drop rows where
             # kev is None (NaN) and time_closed is None (NaT)
             df["kev"].fillna("", inplace=True)
-            df["time_closed"].fillna(
-                NULL_TIMESTAMP, inplace=True, downcast="infer"
-            )  # This changes 'time_closed' dtype to object; downcast='infer' needed to avoid "NotImplementedError: reshaping is not supported for Index objects" (pandas 0.19.1)
+            # This changes 'time_closed' dtype to object
+            df["time_closed"].fillna(NULL_TIMESTAMP, inplace=True)  
             for col in ("time_opened", "time_closed", "last_detected"):
                 df[col] = pd.to_datetime(
                     df[col], utc=True


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR fixes two bugs that were uncovered after #72 was deployed:
* https://github.com/cisagov/cyhy-reports/commit/f75d9d825b1b11985858e73fd6448294c138055c ensures that the `kev_max_age` variable is properly initialized.
* https://github.com/cisagov/cyhy-reports/commit/2d69d4305e43118450b0ea191c3313be8482cd56 modifies two calls to `fillna()` so that they work correctly with pandas `0.23.3` (we previously were using `0.19.1`).

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

These bugs derailed our weekly report generation process, so it's important to fix them as soon as possible.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

These changes were verified by running the full Production reporting process and no issues were encountered.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
