### PR TITLE
Use `chevron` instead of `pystache`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN apt-get update && apt-get -y install \
     python-pandas \
     python-progressbar \
     python-pypdf2 \
-    python-pystache \
     python-unicodecsv \
     texlive \
     texlive-fonts-extra \

--- a/cyhy_report/bod_scorecard/generate_bod_scorecard.py
+++ b/cyhy_report/bod_scorecard/generate_bod_scorecard.py
@@ -30,11 +30,10 @@ import tempfile
 # Third-Party Libraries
 import chevron
 from docopt import docopt
-from pyPdf import PdfFileWriter, PdfFileReader
 
 # cisagov Libraries
 from cyhy.core import *
-from cyhy.db import CHDatabase, database
+from cyhy.db import database
 from cyhy.util import *
 
 # constants

--- a/cyhy_report/bod_scorecard/generate_bod_scorecard.py
+++ b/cyhy_report/bod_scorecard/generate_bod_scorecard.py
@@ -15,36 +15,27 @@ Options:
   --version                      Show version.
 '''
 
-# standard python libraries
-import sys
-import os
-import copy
-from datetime import datetime, timedelta
-from dateutil import parser, relativedelta, tz
-import time
-import json
+# Standard Python Libraries
 import codecs
-import tempfile
+import csv
+from datetime import timedelta
+from dateutil import parser, tz
+import json
+import os
 import shutil
 import subprocess
-import re
-import csv
-from collections import OrderedDict, defaultdict
-import random
+import sys
+import tempfile
 
-# third-party libraries (install with pip)
+# Third-Party Libraries
 import chevron
-from pandas import Series, DataFrame 
-#import pandas as pd
-#import numpy as np 
-from bson import ObjectId
 from docopt import docopt
 from pyPdf import PdfFileWriter, PdfFileReader
 
-# intra-project modules
+# cisagov Libraries
 from cyhy.core import *
+from cyhy.db import CHDatabase, database
 from cyhy.util import *
-from cyhy.db import database, queries, CHDatabase
 
 # constants
 SCORING_ENGINE_VERSION = '1.0'

--- a/cyhy_report/bod_scorecard/generate_bod_scorecard.py
+++ b/cyhy_report/bod_scorecard/generate_bod_scorecard.py
@@ -33,7 +33,7 @@ from collections import OrderedDict, defaultdict
 import random
 
 # third-party libraries (install with pip)
-import pystache
+import chevron
 from pandas import Series, DataFrame 
 #import pandas as pd
 #import numpy as np 
@@ -658,13 +658,12 @@ class ScorecardGenerator(object):
             out.write(to_json(result))
         
     def __generate_latex(self, mustache_file, json_file, latex_file):
-        renderer = pystache.Renderer()
         template = codecs.open(mustache_file,'r', encoding='utf-8').read()
 
         with codecs.open(json_file,'r', encoding='utf-8') as data_file:
             data = json.load(data_file)
 
-        r = pystache.render(template, data)
+        r = chevron.render(template, data)
         with codecs.open(latex_file,'w', encoding='utf-8') as output:
             output.write(r)
 

--- a/cyhy_report/customer/generate_report.py
+++ b/cyhy_report/customer/generate_report.py
@@ -40,6 +40,7 @@ import tempfile
 
 # Third-Party Libraries
 from bson import ObjectId
+import chevron
 from dateutil import parser, tz
 from docopt import docopt
 from netaddr import IPAddress
@@ -47,7 +48,6 @@ import numpy as np
 import pandas as pd
 from pandas import DataFrame, Series
 from pyPdf import PdfFileReader, PdfFileWriter
-import pystache
 from unicodecsv import DictWriter
 
 # cisagov Libraries
@@ -3397,13 +3397,12 @@ class ReportGenerator(object):
             out.write(to_json(result))
 
     def __generate_latex(self, mustache_file, json_file, latex_file):
-        renderer = pystache.Renderer()
         template = codecs.open(mustache_file, "r", encoding="utf-8").read()
 
         with codecs.open(json_file, "r", encoding="utf-8") as data_file:
             data = json.load(data_file)
 
-        r = pystache.render(template, data)
+        r = chevron.render(template, data)
         with codecs.open(latex_file, "w", encoding="utf-8") as output:
             output.write(r)
 

--- a/cyhy_report/customer/report.mustache
+++ b/cyhy_report/customer/report.mustache
@@ -840,7 +840,7 @@ subdomains under them. Per the directive, agencies shall monitor
 Detailed information on the certificates discovered by \gls{CISA} can
 be found in the
 \hyperref[app:attachments]{\texttt{certificates.csv}} attachment
-within the agency’s weekly Cyber Hygiene report.
+within the agency's weekly Cyber Hygiene report.
 <</is_suborg>>
 <<#is_suborg>>
 We have no way to associate an organization's second-level domains

--- a/cyhy_report/cybex_scorecard/generate_cybex_scorecard.py
+++ b/cyhy_report/cybex_scorecard/generate_cybex_scorecard.py
@@ -36,7 +36,7 @@ from collections import defaultdict
 import random
 
 # third-party libraries (install with pip)
-import pystache
+import chevron
 from pandas import Series, DataFrame
 import pandas as pd
 import numpy as np
@@ -3336,13 +3336,12 @@ class ScorecardGenerator(object):
             out.write(to_json(result))
 
     def __generate_latex(self, mustache_file, json_file, latex_file):
-        renderer = pystache.Renderer()
         template = codecs.open(mustache_file,'r', encoding='utf-8').read()
 
         with codecs.open(json_file,'r', encoding='utf-8') as data_file:
             data = json.load(data_file)
 
-        r = pystache.render(template, data)
+        r = chevron.render(template, data)
         with codecs.open(latex_file,'w', encoding='utf-8') as output:
             output.write(r)
 

--- a/cyhy_report/cybex_scorecard/generate_cybex_scorecard.py
+++ b/cyhy_report/cybex_scorecard/generate_cybex_scorecard.py
@@ -20,34 +20,34 @@ CYHY_DB_SECTION and SCAN_DB_SECTION refer to sections
 within /etc/cyhy/cyhy.conf
 '''
 
-# standard python libraries
-import sys
-import os
+# Standard Python Libraries
+from collections import defaultdict
+import codecs
 import copy
+import csv
 from datetime import timedelta
 from dateutil import parser
 import json
-import codecs
-import tempfile
+import os
+import random
 import shutil
 import subprocess
-import csv
-from collections import defaultdict
-import random
+import sys
+import tempfile
 
-# third-party libraries (install with pip)
-import chevron
-from pandas import Series, DataFrame
-import pandas as pd
-import numpy as np
+# Third-Party Libraries
 from bson import ObjectId
+import chevron
 from docopt import docopt
+import numpy as np
+import pandas as pd
+from pandas import Series, DataFrame
 import requests
 
-# intra-project modules
+# cisagov Libraries
 from cyhy.core import *
-from cyhy.util import *
 from cyhy.db import database, scheduler
+from cyhy.util import *
 import graphs
 
 # constants

--- a/cyhy_report/cyhy_notification/generate_notification.py
+++ b/cyhy_report/cyhy_notification/generate_notification.py
@@ -31,10 +31,10 @@ import sys
 import tempfile
 
 # third-party libraries (install with pip)
+import chevron
 from docopt import docopt
 from netaddr import IPAddress
 from pyPdf import PdfFileWriter, PdfFileReader
-import pystache
 
 # intra-project modules
 from cyhy.core import Config
@@ -574,7 +574,7 @@ class NotificationGenerator(object):
         with codecs.open(json_file, "r", encoding="utf-8") as data_file:
             data = json.load(data_file)
 
-        r = pystache.render(template, data)
+        r = chevron.render(template, data)
         with codecs.open(latex_file, "w", encoding="utf-8") as output:
             output.write(r)
 

--- a/cyhy_report/cyhy_notification/generate_notification.py
+++ b/cyhy_report/cyhy_notification/generate_notification.py
@@ -19,7 +19,7 @@ Options:
                                  cyhy database.
 """
 
-# standard python libraries
+# Standard Python Libraries
 import codecs
 import csv
 import json
@@ -30,13 +30,13 @@ import subprocess
 import sys
 import tempfile
 
-# third-party libraries (install with pip)
+# Third-Party Libraries
 import chevron
 from docopt import docopt
 from netaddr import IPAddress
 from pyPdf import PdfFileWriter, PdfFileReader
 
-# intra-project modules
+# cisagov Libraries
 from cyhy.core import Config
 from cyhy.db import database
 from cyhy.util import to_json, utcnow

--- a/cyhy_report/m1513_scorecard/generate_m1513_scorecard.py
+++ b/cyhy_report/m1513_scorecard/generate_m1513_scorecard.py
@@ -32,7 +32,6 @@ from bson import ObjectId
 import chevron
 from docopt import docopt
 import matplotlib.pyplot as plt
-from pyPdf import PdfFileWriter, PdfFileReader
 
 # cisagov Libraries
 from cyhy.core import *

--- a/cyhy_report/m1513_scorecard/generate_m1513_scorecard.py
+++ b/cyhy_report/m1513_scorecard/generate_m1513_scorecard.py
@@ -34,7 +34,7 @@ import numpy as np
 
 
 # third-party libraries (install with pip)
-import pystache
+import chevron
 from pandas import Series, DataFrame 
 import pandas as pd
 #import numpy as np 
@@ -542,13 +542,12 @@ class ScorecardGenerator(object):
       
 
     def __generate_latex(self, mustache_file, json_file, latex_file):
-        renderer = pystache.Renderer()
         template = codecs.open(mustache_file,'r', encoding='utf-8').read()
 
         with codecs.open(json_file,'r', encoding='utf-8') as data_file:
             data = json.load(data_file)
 
-        r = pystache.render(template, data)
+        r = chevron.render(template, data)
         with codecs.open(latex_file,'w', encoding='utf-8') as output:
             output.write(r)
 

--- a/cyhy_report/m1513_scorecard/generate_m1513_scorecard.py
+++ b/cyhy_report/m1513_scorecard/generate_m1513_scorecard.py
@@ -13,43 +13,30 @@ Options:
   --version                      Show version.
   -s SECTION --section=SECTION   Configuration section to use.
 '''
-# standard python libraries
-import sys
-import os
-import copy
-from pymongo import MongoClient
-from datetime import datetime, timedelta
-from dateutil import parser, relativedelta, tz
-import time
-import json
+
+# Standard Python Libraries
+from dateutil import parser
 import codecs
-import tempfile
+import csv
+import json
+import numpy as np
+import os
+from pymongo import MongoClient
 import shutil
 import subprocess
-import re
-import csv
-from collections import OrderedDict, defaultdict
-import random
-import numpy as np
+import sys
+import tempfile
 
-
-# third-party libraries (install with pip)
-import chevron
-from pandas import Series, DataFrame 
-import pandas as pd
-#import numpy as np 
+# Third-Party Libraries
 from bson import ObjectId
+import chevron
 from docopt import docopt
-from pyPdf import PdfFileWriter, PdfFileReader
 import matplotlib.pyplot as plt
-from matplotlib import font_manager as fm
+from pyPdf import PdfFileWriter, PdfFileReader
 
-
-
-# intra-project modules
+# cisagov Libraries
 from cyhy.core import *
 from cyhy.util import *
-from cyhy.db import database, queries, CHDatabase
 import graphs
 
 # constants

--- a/cyhy_report/scorecard/generate_scorecard.py
+++ b/cyhy_report/scorecard/generate_scorecard.py
@@ -36,8 +36,8 @@ from collections import OrderedDict
 import random
 
 # third-party libraries (install with pip)
+import chevron
 import dateutil
-import pystache
 from pandas import Series, DataFrame 
 import pandas as pd
 import numpy as np 
@@ -579,13 +579,12 @@ class ScorecardGenerator(object):
             out.write(to_json(result))
         
     def __generate_latex(self, mustache_file, json_file, latex_file):
-        renderer = pystache.Renderer()
         template = codecs.open(mustache_file,'r', encoding='utf-8').read()
 
         with codecs.open(json_file,'r', encoding='utf-8') as data_file:
             data = json.load(data_file)
 
-        r = pystache.render(template, data)
+        r = chevron.render(template, data)
         with codecs.open(latex_file,'w', encoding='utf-8') as output:
             output.write(r)
 

--- a/cyhy_report/scorecard/generate_scorecard.py
+++ b/cyhy_report/scorecard/generate_scorecard.py
@@ -19,36 +19,31 @@ Options:
   --version                      Show version.
 '''
 
-# standard python libraries
-import sys
-import os
-import copy
-from datetime import datetime, timedelta
-import time
-import json
+# Standard Python Libraries
 import codecs
-import tempfile
+import csv
+from datetime import timedelta
+import json
+import os
+import random
+import re
 import shutil
 import subprocess
-import re
-import csv
-from collections import OrderedDict
-import random
+import sys
+import tempfile
 
-# third-party libraries (install with pip)
+# Third-Party Libraries
+from bson import ObjectId
 import chevron
 import dateutil
-from pandas import Series, DataFrame 
-import pandas as pd
-import numpy as np 
-from bson import ObjectId
 from docopt import docopt
+import numpy as np 
 from pyPdf import PdfFileWriter, PdfFileReader
 
-# intra-project modules
+# cisagov Libraries
 from cyhy.core import *
-from cyhy.util import *
 from cyhy.db import database, CHDatabase
+from cyhy.util import *
 import queries
 
 # constants

--- a/cyhy_report/scorecard/generate_scorecard.py
+++ b/cyhy_report/scorecard/generate_scorecard.py
@@ -37,12 +37,11 @@ from bson import ObjectId
 import chevron
 import dateutil
 from docopt import docopt
-import numpy as np 
-from pyPdf import PdfFileWriter, PdfFileReader
+import numpy as np
 
 # cisagov Libraries
 from cyhy.core import *
-from cyhy.db import database, CHDatabase
+from cyhy.db import database
 from cyhy.util import *
 import queries
 

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         # version of numpy and that is a can of worms that we don't want to open
         # at this time.
         "basemap @ https://github.com/matplotlib/basemap/archive/refs/tags/v1.2.2rel.zip",
+        "chevron >= 0.14.0",
         "cyhy-core >= 0.0.2",
         "docopt >= 0.6.2",
         "matplotlib == 1.5.3",
@@ -64,7 +65,6 @@ setup(
         "pandas == 0.23.3",
         "progressbar >=2.3-dev",
         "pyPdf >= 1.13",
-        "pystache >= 0.5.3",
         "python-dateutil >= 2.2",
         "requests >= 2.21.0",
         "unicodecsv >= 0.9.4",


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR swaps in the [`chevron`](https://pypi.org/project/chevron/) package wherever `pystache` is used.

Also, I took this opportunity to clean up the import sections of the various report-generating scripts (see https://github.com/cisagov/cyhy-reports/commit/3607aaadf614d92d64ee97231774d39f8bdae56c).

During my testing, I uncovered a sneaky non-ASCII character in one of our mustache files, so I fixed that in https://github.com/cisagov/cyhy-reports/pull/74/commits/54e4daf5a4a5cb5dd52afb32dd7006db2779954a.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

After the deployment of #72, we encountered an issue with `pystache` where it was HTML-encoding apostrophe characters, which was causing `xelatex` to fail to render a PDF.  We believe this is related to our recent change from python `2.7.13` to `2.7.16`, though we are not sure of the exact source.  Nevertheless, we tested `chevron` and found that it was not exhibiting that same behavior.  We have been moving away from `pystache` because it is no longer supported, plus `chevron` is faster too.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Of the scripts updated here, only three are still in regular use: `customer/generate_report.py`, `cybex_scorecard/generate_cybex_scorecard`, and `cyhy_notification/generate_notification.py`.  

Those three scripts were successfully tested in Production with these changes.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
