### PR TITLE
Decode `chevron` output before writing LaTeX file

### DIFF
--- a/cyhy_report/bod_scorecard/generate_bod_scorecard.py
+++ b/cyhy_report/bod_scorecard/generate_bod_scorecard.py
@@ -653,7 +653,7 @@ class ScorecardGenerator(object):
         with codecs.open(json_file,'r', encoding='utf-8') as data_file:
             data = json.load(data_file)
 
-        r = chevron.render(template, data)
+        r = chevron.render(template, data).decode('utf-8')
         with codecs.open(latex_file,'w', encoding='utf-8') as output:
             output.write(r)
 

--- a/cyhy_report/customer/generate_report.py
+++ b/cyhy_report/customer/generate_report.py
@@ -3401,7 +3401,7 @@ class ReportGenerator(object):
         with codecs.open(json_file, "r", encoding="utf-8") as data_file:
             data = json.load(data_file)
 
-        r = chevron.render(template, data)
+        r = chevron.render(template, data).decode("utf-8")
         with codecs.open(latex_file, "w", encoding="utf-8") as output:
             output.write(r)
 

--- a/cyhy_report/cybex_scorecard/generate_cybex_scorecard.py
+++ b/cyhy_report/cybex_scorecard/generate_cybex_scorecard.py
@@ -3341,7 +3341,7 @@ class ScorecardGenerator(object):
         with codecs.open(json_file,'r', encoding='utf-8') as data_file:
             data = json.load(data_file)
 
-        r = chevron.render(template, data)
+        r = chevron.render(template, data).decode('utf-8')
         with codecs.open(latex_file,'w', encoding='utf-8') as output:
             output.write(r)
 

--- a/cyhy_report/cyhy_notification/generate_notification.py
+++ b/cyhy_report/cyhy_notification/generate_notification.py
@@ -574,7 +574,7 @@ class NotificationGenerator(object):
         with codecs.open(json_file, "r", encoding="utf-8") as data_file:
             data = json.load(data_file)
 
-        r = chevron.render(template, data)
+        r = chevron.render(template, data).decode("utf-8")
         with codecs.open(latex_file, "w", encoding="utf-8") as output:
             output.write(r)
 

--- a/cyhy_report/m1513_scorecard/generate_m1513_scorecard.py
+++ b/cyhy_report/m1513_scorecard/generate_m1513_scorecard.py
@@ -533,7 +533,7 @@ class ScorecardGenerator(object):
         with codecs.open(json_file,'r', encoding='utf-8') as data_file:
             data = json.load(data_file)
 
-        r = chevron.render(template, data)
+        r = chevron.render(template, data).decode('utf-8')
         with codecs.open(latex_file,'w', encoding='utf-8') as output:
             output.write(r)
 

--- a/cyhy_report/scorecard/generate_scorecard.py
+++ b/cyhy_report/scorecard/generate_scorecard.py
@@ -578,7 +578,7 @@ class ScorecardGenerator(object):
         with codecs.open(json_file,'r', encoding='utf-8') as data_file:
             data = json.load(data_file)
 
-        r = chevron.render(template, data)
+        r = chevron.render(template, data).decode('utf-8')
         with codecs.open(latex_file,'w', encoding='utf-8') as output:
             output.write(r)
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR decodes the UTF-8 output from `chevron` prior to writing the LaTeX output to a file.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Since [`chevron` output is UTF-8 encoded by default in Python 2](https://github.com/noahmorrison/chevron/blob/main/chevron/renderer.py#L383), we decode it before we write it out to a file (re-encoded as UTF-8).  This was previously not necessary since `pystache` did not output UTF-8-encoded data.  This detail was missed when #74 was tested, most likely because there were no Unicode characters in the test output.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Of the scripts updated here, only three are still in regular use: `customer/generate_report.py`, `cybex_scorecard/generate_cybex_scorecard`, and `cyhy_notification/generate_notification.py`.

Those three scripts were successfully tested in a test environment with these changes.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
