### PR TITLE
Handle notifications with large number of tickets and use `docker compose` syntax

### DIFF
--- a/cyhy_report/cyhy_notification/generate_notification.py
+++ b/cyhy_report/cyhy_notification/generate_notification.py
@@ -285,9 +285,6 @@ class NotificationGenerator(object):
         )
 
         for ticket in tickets:
-            # Neuter this monstrosity so it can't be saved (easily)
-            ticket.connection = None
-
             # Flatten structure by copying details to ticket root
             ticket.update(ticket["details"])
 
@@ -296,7 +293,7 @@ class NotificationGenerator(object):
                 ticket["based_on_vulnscan"] = True
                 ticket["based_on_portscan"] = False
                 try:
-                    latest_vuln = ticket.latest_vuln()
+                    latest_vuln = self.__cyhy_db.TicketDoc(ticket).latest_vuln()
                 except database.VulnScanNotFoundException as e:
                     print("\n  Warning (non-fatal): {}".format(e.message))
                     # The vuln_scan has likely been archived; get the vuln_scan
@@ -315,7 +312,7 @@ class NotificationGenerator(object):
                 ticket["based_on_portscan"] = True
                 ticket["based_on_vulnscan"] = False
                 try:
-                    latest_port = ticket.latest_port()
+                    latest_port = self.__cyhy_db.TicketDoc(ticket).latest_port()
                 except database.PortScanNotFoundException as e:
                     print("\n  Warning (non-fatal): {}".format(e.message))
                     # The port_scan has likely been archived; get the port_scan

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -133,7 +133,8 @@ def main():
         os.chdir(CYHY_MAILER_DIR)
         p = subprocess.Popen(
             [
-                "docker-compose",
+                "docker",
+                "compose",
                 "-f",
                 "docker-compose.yml",
                 "-f",


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR resolves a situation where a Mongo query can run out of memory and fail if a notification contains a large number of tickets.

In addition, https://github.com/cisagov/cyhy-reports/pull/77/commits/5485ed9f93fc36d2ec1cade471fb302cc9839988 updates `create_send_notifications.py` to use the newer `docker compose` syntax instead of the older style `docker-compose` syntax.  The `docker compose` syntax is the preferred (and only correct) syntax after the changes in https://github.com/cisagov/ansible-role-docker/pull/60.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

After our recent switch to CVSS v3 (see https://github.com/cisagov/cyhy-core/pull/69 and https://github.com/cisagov/cyhy-reports/pull/76), our daily notification process failed because one of the organizations had a very large number of tickets to process for their notification.  The process failed with this error:

```
Jun 10 08:15:55 reporter cyhy-notifications: 2022-06-10 08:15:55,705 INFO <ORG_ID> - Starting to create notification PDF
Jun 10 08:15:56 reporter cyhy-notifications: Traceback (most recent call last):
Jun 10 08:15:56 reporter cyhy-notifications:   File "./create_send_notifications.py", line 184, in <module>
Jun 10 08:15:56 reporter cyhy-notifications:     sys.exit(main())
Jun 10 08:15:56 reporter cyhy-notifications:   File "./create_send_notifications.py", line 115, in main
Jun 10 08:15:56 reporter cyhy-notifications:     num_pdfs_created = generate_notification_pdfs(db, cyhy_org_ids, master_report_key)
Jun 10 08:15:56 reporter cyhy-notifications:   File "./create_send_notifications.py", line 72, in generate_notification_pdfs
Jun 10 08:15:56 reporter cyhy-notifications:     was_encrypted, results = generator.generate_notification()
Jun 10 08:15:56 reporter cyhy-notifications:   File "/usr/local/lib/python2.7/dist-packages/cyhy_report/cyhy_notification/generate_notification.py", line 162, in generate_notification
Jun 10 08:15:56 reporter cyhy-notifications:     self.__run_queries()
Jun 10 08:15:56 reporter cyhy-notifications:   File "/usr/local/lib/python2.7/dist-packages/cyhy_report/cyhy_notification/generate_notification.py", line 361, in __run_queries
Jun 10 08:15:56 reporter cyhy-notifications:     self.__results["tickets"] = self.__load_tickets(ticket_ids)
Jun 10 08:15:56 reporter cyhy-notifications:   File "/usr/local/lib/python2.7/dist-packages/cyhy_report/cyhy_notification/generate_notification.py", line 271, in __load_tickets
Jun 10 08:15:56 reporter cyhy-notifications:     ("details.name", 1),
Jun 10 08:15:56 reporter cyhy-notifications:   File "/usr/local/lib/python2.7/dist-packages/mongokit/cursor.py", line 42, in next
Jun 10 08:15:56 reporter cyhy-notifications:     if len(self.__data) or self._refresh():
Jun 10 08:15:56 reporter cyhy-notifications:   File "/usr/local/lib/python2.7/dist-packages/pymongo/cursor.py", line 1095, in _refresh
Jun 10 08:15:56 reporter cyhy-notifications:     self.__codec_options.uuid_representation))
Jun 10 08:15:56 reporter cyhy-notifications:   File "/usr/local/lib/python2.7/dist-packages/pymongo/cursor.py", line 1037, in __send_message
Jun 10 08:15:56 reporter cyhy-notifications:     self.__compile_re)
Jun 10 08:15:56 reporter cyhy-notifications:   File "/usr/local/lib/python2.7/dist-packages/pymongo/helpers.py", line 144, in _unpack_response
Jun 10 08:15:56 reporter cyhy-notifications:     error_object)
Jun 10 08:15:56 reporter cyhy-notifications: pymongo.errors.OperationFailure: database error: Executor error during OP_QUERY find :: caused by :: errmsg: "Sort operation used more than the maximum 33554432 bytes of RAM. Add an index, or specify a smaller limit."
```

I first attempted to fix this by adding a new index to support this sort, but I was unable to get the sort to use that index.  So instead, I worked around this issue by switching to a Mongo `aggregate` query, which allowed me to use the [`allowDiskUse` option](https://www.mongodb.com/docs/v3.6/reference/method/db.collection.aggregate/#method-aggregate-allowdiskuse) to circumvent the memory limitation.
 
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

To test these changes, I first verified that I could manually create a notification for the organization that failed with the memory error, and that was successful.  I then created a fresh notification for an org that had previously (this morning) successfully generated a notification, and I compared those two docs to ensure that they were identical (they were).

Finally, I executed the entire daily notification process, which ran without any errors.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

