### PR TITLE
Handle unicode data in CSVs

### DIFF
--- a/cyhy_report/bod_scorecard/generate_bod_scorecard.py
+++ b/cyhy_report/bod_scorecard/generate_bod_scorecard.py
@@ -17,7 +17,6 @@ Options:
 
 # Standard Python Libraries
 import codecs
-import csv
 from datetime import timedelta
 from dateutil import parser, tz
 import json
@@ -30,6 +29,7 @@ import tempfile
 # Third-Party Libraries
 import chevron
 from docopt import docopt
+import unicodecsv as csv
 
 # cisagov Libraries
 from cyhy.core import *

--- a/cyhy_report/customer/generate_report.py
+++ b/cyhy_report/customer/generate_report.py
@@ -28,7 +28,6 @@ Options:
 # Standard Python Libraries
 import codecs
 from collections import OrderedDict
-import csv
 import datetime
 import json
 import os
@@ -48,7 +47,7 @@ import numpy as np
 import pandas as pd
 from pandas import DataFrame, Series
 from pyPdf import PdfFileReader, PdfFileWriter
-from unicodecsv import DictWriter
+import unicodecsv as csv
 
 # cisagov Libraries
 from cyhy.core import *
@@ -2401,7 +2400,7 @@ class ReportGenerator(object):
                 # unknown field appears it indicates an error
                 # (probably a typo).  That's why we're using
                 # extrasaction='raise' here.
-                writer = DictWriter(f, fields, extrasaction="raise")
+                writer = csv.DictWriter(f, fields, extrasaction="raise")
                 writer.writeheader()
                 for d in data:
                     not_after = d["not_after"].replace(tzinfo=today.tzinfo)
@@ -2575,9 +2574,9 @@ class ReportGenerator(object):
                 )
         data = self.__results["tickets_0"]
         with open("findings.csv", "wb") as out_file:
-            header_writer = DictWriter(out_file, header_fields, extrasaction="ignore")
+            header_writer = csv.DictWriter(out_file, header_fields, extrasaction="ignore")
             header_writer.writeheader()
-            data_writer = DictWriter(out_file, data_fields, extrasaction="ignore")
+            data_writer = csv.DictWriter(out_file, data_fields, extrasaction="ignore")
             for row in data:
                 data_writer.writerow(row)
 
@@ -2624,9 +2623,9 @@ class ReportGenerator(object):
             )
         data = self.__results["resolved_vulnerabilities"]
         with open("mitigated-vulnerabilities.csv", "wb") as out_file:
-            header_writer = DictWriter(out_file, header_fields, extrasaction="ignore")
+            header_writer = csv.DictWriter(out_file, header_fields, extrasaction="ignore")
             header_writer.writeheader()
-            data_writer = DictWriter(out_file, data_fields, extrasaction="ignore")
+            data_writer = csv.DictWriter(out_file, data_fields, extrasaction="ignore")
             for row in data:
                 # If enough time has passed between snapshot creation and report generation,
                 # we may see tickets that were closed when the snapshot was created, but
@@ -2692,9 +2691,9 @@ class ReportGenerator(object):
             )
         data = self.__results["recently_detected_closed_tickets"]
         with open("recently-detected.csv", "wb") as out_file:
-            header_writer = DictWriter(out_file, header_fields, extrasaction="ignore")
+            header_writer = csv.DictWriter(out_file, header_fields, extrasaction="ignore")
             header_writer.writeheader()
-            data_writer = DictWriter(out_file, data_fields, extrasaction="ignore")
+            data_writer = csv.DictWriter(out_file, data_fields, extrasaction="ignore")
             for row in data:
                 data_writer.writerow(row)
 
@@ -2709,7 +2708,7 @@ class ReportGenerator(object):
                 fields = ("ip_int", "ip", "port", "service")
         data = self.__results["services_attachment"]
         with open("services.csv", "wb") as out_file:
-            writer = DictWriter(out_file, fields, extrasaction="ignore")
+            writer = csv.DictWriter(out_file, fields, extrasaction="ignore")
             writer.writeheader()
             for row in data:
                 writer.writerow(row)
@@ -2746,7 +2745,7 @@ class ReportGenerator(object):
                 )
         data = self.__results["risky_services_tickets"]
         with open("potentially-risky-services.csv", "wb") as out_file:
-            writer = DictWriter(out_file, fields, extrasaction="ignore")
+            writer = csv.DictWriter(out_file, fields, extrasaction="ignore")
             writer.writeheader()
             for row in data:
                 writer.writerow(row)
@@ -2765,8 +2764,8 @@ class ReportGenerator(object):
                 data_fields = ("ip_int", "ip", "name", "hostname")
         data = self.__results["hosts_attachment"]
         with open("hosts.csv", "wb") as out_file:
-            header_writer = DictWriter(out_file, header_fields, extrasaction="ignore")
-            data_writer = DictWriter(out_file, data_fields, extrasaction="ignore")
+            header_writer = csv.DictWriter(out_file, header_fields, extrasaction="ignore")
+            data_writer = csv.DictWriter(out_file, data_fields, extrasaction="ignore")
             header_writer.writeheader()
             for row in data:
                 data_writer.writerow(row)
@@ -2781,7 +2780,7 @@ class ReportGenerator(object):
             header_fields = ("cidr", "first", "last", "count")
         data = self.__snapshots[0]["networks"]
         with open("scope.csv", "wb") as out_file:
-            writer = DictWriter(out_file, header_fields, extrasaction="ignore")
+            writer = csv.DictWriter(out_file, header_fields, extrasaction="ignore")
             writer.writeheader()
             for net in data:
                 if self.__anonymize:
@@ -2889,9 +2888,9 @@ class ReportGenerator(object):
                 )
         data = self.__results["false_positive_tickets"]
         with open("false-positive-findings.csv", "wb") as out_file:
-            header_writer = DictWriter(out_file, header_fields, extrasaction="ignore")
+            header_writer = csv.DictWriter(out_file, header_fields, extrasaction="ignore")
             header_writer.writeheader()
-            data_writer = DictWriter(out_file, data_fields, extrasaction="ignore")
+            data_writer = csv.DictWriter(out_file, data_fields, extrasaction="ignore")
             for row in data:
                 data_writer.writerow(row)
 
@@ -2942,11 +2941,11 @@ class ReportGenerator(object):
                 "tix_days_open.low.median",
             )
             with open("sub-org-summary.csv", "wb") as out_file:
-                header_writer = DictWriter(
+                header_writer = csv.DictWriter(
                     out_file, header_fields, extrasaction="ignore"
                 )
                 header_writer.writeheader()
-                data_writer = DictWriter(out_file, data_fields, extrasaction="ignore")
+                data_writer = csv.DictWriter(out_file, data_fields, extrasaction="ignore")
                 # Output data from descendant orgs
                 for row in self.__results["ss0_descendant_data"]:
                     for severity in ("critical", "high", "medium", "low"):
@@ -3008,9 +3007,9 @@ class ReportGenerator(object):
             "tix_closed_after_date",
         )
         with open("days-to-mitigate.csv", "wb") as out_file:
-            header_writer = DictWriter(out_file, header_fields, extrasaction="ignore")
+            header_writer = csv.DictWriter(out_file, header_fields, extrasaction="ignore")
             header_writer.writeheader()
-            data_writer = DictWriter(out_file, data_fields, extrasaction="ignore")
+            data_writer = csv.DictWriter(out_file, data_fields, extrasaction="ignore")
             for snap in self.__snapshots:
                 snap["report_date"] = snap["tix_msec_open"][
                     "tix_open_as_of_date"
@@ -3051,9 +3050,9 @@ class ReportGenerator(object):
             "tix_days_open.low.max",
         )
         with open("days-currently-active.csv", "wb") as out_file:
-            header_writer = DictWriter(out_file, header_fields, extrasaction="ignore")
+            header_writer = csv.DictWriter(out_file, header_fields, extrasaction="ignore")
             header_writer.writeheader()
-            data_writer = DictWriter(out_file, data_fields, extrasaction="ignore")
+            data_writer = csv.DictWriter(out_file, data_fields, extrasaction="ignore")
             for snap in self.__snapshots:
                 snap["report_date"] = snap["tix_msec_open"][
                     "tix_open_as_of_date"
@@ -3542,7 +3541,7 @@ def main():
         print "Generating overview CSV ...",
         fields = overview_data[0].keys()
         with open(args["--overview"], "w") as csv_out:
-            csv_writer = DictWriter(csv_out, fields, extrasaction="ignore")
+            csv_writer = csv.DictWriter(csv_out, fields, extrasaction="ignore")
             csv_writer.writeheader()
             for row in overview_data:
                 csv_writer.writerow(row)

--- a/cyhy_report/cybex_scorecard/generate_cybex_scorecard.py
+++ b/cyhy_report/cybex_scorecard/generate_cybex_scorecard.py
@@ -24,7 +24,6 @@ within /etc/cyhy/cyhy.conf
 from collections import defaultdict
 import codecs
 import copy
-import csv
 from datetime import timedelta
 from dateutil import parser
 import json
@@ -43,6 +42,7 @@ import numpy as np
 import pandas as pd
 from pandas import Series, DataFrame
 import requests
+import unicodecsv as csv
 
 # cisagov Libraries
 from cyhy.core import *

--- a/cyhy_report/cyhy_notification/generate_notification.py
+++ b/cyhy_report/cyhy_notification/generate_notification.py
@@ -21,7 +21,6 @@ Options:
 
 # Standard Python Libraries
 import codecs
-import csv
 import json
 import os
 import re
@@ -35,6 +34,7 @@ import chevron
 from docopt import docopt
 from netaddr import IPAddress
 from pyPdf import PdfFileWriter, PdfFileReader
+import unicodecsv as csv
 
 # cisagov Libraries
 from cyhy.core import Config

--- a/cyhy_report/m1513_scorecard/generate_m1513_scorecard.py
+++ b/cyhy_report/m1513_scorecard/generate_m1513_scorecard.py
@@ -17,7 +17,6 @@ Options:
 # Standard Python Libraries
 from dateutil import parser
 import codecs
-import csv
 import json
 import numpy as np
 import os
@@ -32,6 +31,7 @@ from bson import ObjectId
 import chevron
 from docopt import docopt
 import matplotlib.pyplot as plt
+import unicodecsv as csv
 
 # cisagov Libraries
 from cyhy.core import *

--- a/cyhy_report/scorecard/generate_scorecard.py
+++ b/cyhy_report/scorecard/generate_scorecard.py
@@ -21,7 +21,6 @@ Options:
 
 # Standard Python Libraries
 import codecs
-import csv
 from datetime import timedelta
 import json
 import os
@@ -38,6 +37,7 @@ import chevron
 import dateutil
 from docopt import docopt
 import numpy as np
+import unicodecsv as csv
 
 # cisagov Libraries
 from cyhy.core import *

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,6 @@ setup(
         "pyPdf >= 1.13",
         "python-dateutil >= 2.2",
         "requests >= 2.21.0",
-        "unicodecsv >= 0.9.4",
+        "unicodecsv >= 0.14.1",
     ],
 )


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates all of our reporting scripts to use the [`unicodecsv` module](https://pypi.org/project/unicodecsv/) instead of the `csv` module built in to Python 2.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This repo previously used `unicodecsv` for the CSVs in the [primary CyHy customer report](https://github.com/cisagov/cyhy-reports/blob/4176bace0e6b9c754ec37c9cc6e8dcdaf97815cc/cyhy_report/customer/generate_report.py#L51), but other reports like the [Cyber Exposure scorecard](https://github.com/cisagov/cyhy-reports/tree/develop/cyhy_report/cybex_scorecard) and [daily notifications](https://github.com/cisagov/cyhy-reports/tree/develop/cyhy_report/cyhy_notification) were not using it.  This led to a situation recently where the daily notifications process failed with this error:
```
Jun 13 09:10:18 reporter cyhy-notifications:   File "./create_send_notifications.py", line 185, in <module>
Jun 13 09:10:18 reporter cyhy-notifications:     sys.exit(main())
Jun 13 09:10:18 reporter cyhy-notifications:   File "./create_send_notifications.py", line 115, in main
Jun 13 09:10:18 reporter cyhy-notifications:     num_pdfs_created = generate_notification_pdfs(db, cyhy_org_ids, master_report_key)
Jun 13 09:10:18 reporter cyhy-notifications:   File "./create_send_notifications.py", line 72, in generate_notification_pdfs
Jun 13 09:10:18 reporter cyhy-notifications:     was_encrypted, results = generator.generate_notification()
Jun 13 09:10:18 reporter cyhy-notifications:   File "/usr/local/lib/python2.7/dist-packages/cyhy_report/cyhy_notification/generate_notification.py", line 194, in generate_notification
Jun 13 09:10:18 reporter cyhy-notifications:     self.__generate_attachments()
Jun 13 09:10:18 reporter cyhy-notifications:   File "/usr/local/lib/python2.7/dist-packages/cyhy_report/cyhy_notification/generate_notification.py", line 441, in __generate_attachments
Jun 13 09:10:18 reporter cyhy-notifications:     self.__generate_findings_attachment()
Jun 13 09:10:18 reporter cyhy-notifications:   File "/usr/local/lib/python2.7/dist-packages/cyhy_report/cyhy_notification/generate_notification.py", line 498, in __generate_findings_attachment
Jun 13 09:10:18 reporter cyhy-notifications:     data_writer.writerow(ticket)
Jun 13 09:10:18 reporter cyhy-notifications:   File "/usr/lib/python2.7/csv.py", line 152, in writerow
Jun 13 09:10:18 reporter cyhy-notifications:     return self.writer.writerow(self._dict_to_list(rowdict))
Jun 13 09:10:18 reporter cyhy-notifications: UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 2135: ordinal not in range(128)
```

This PR rectifies that situation and ensures that all of our CSVs are now able to handle unicode data.

Note that this PR is similar to https://github.com/cisagov/cyhy-reports/pull/75.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Of the scripts updated here, only three are still in regular use: `customer/generate_report.py`, `cybex_scorecard/generate_cybex_scorecard`, and `cyhy_notification/generate_notification.py`.  I deployed these changes to a `reporter` instance and verified that I was able to successfully generate several CyHy customer reports, a Cyber Exposure scorecard, and a daily notification (this change was used to generate all of the daily notifications today after this morning's failure, mentioned above).  In each case, I verified that the CSVs were created as expected.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
