### PR TITLE
Install libgeos-3.7.1 in the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ USER root
 
 # Install required packages
 RUN apt-get update && apt-get -y install \
-    libgeos-3.5.1 \
+    libgeos-3.7.1 \
     libgeos-dev \
     python-dateutil \
     python-docopt \


### PR DESCRIPTION

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR modifies the Dockerfile to install [version 3.7.1 of the `libgeos` package](https://packages.debian.org/buster/libgeos-3.7.1) in the Docker image for this repository.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The previous version (`libegeos-3.5.1`) existed in the Debian Stretch package repository, however it is unavailable for Debian Buster, which is the current OS used for this Docker image.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I verified that I was able to successfully build a Docker image using this change.  Without this change, I was unable to build an image:

```
13.87 E: Unable to locate package libgeos-3.5.1
13.87 E: Couldn't find any package by glob 'libgeos-3.5.1'
13.87 E: Couldn't find any package by regex 'libgeos-3.5.1'
```

Once the image was built, I confirmed that I was able to successfully use the image to generate some reports.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
