### PR TITLE
Create open & closed "risky services" CSVs

### DIFF
--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -757,6 +757,14 @@ def pull_cybex_ticket_csvs(db):
         shutil.copy(path, latest_path)
 
     save_csv(
+        "cybex_open_tickets_potentially_risky_services_{}.csv".format(today),
+        cybex_queries.csv_get_open_tickets(db, "risky_services"),
+    )
+    save_csv(
+        "cybex_closed_tickets_potentially_risky_services_{}.csv".format(today),
+        cybex_queries.csv_get_closed_tickets(db, "risky_services"),
+    )
+    save_csv(
         "cybex_open_tickets_urgent_{}.csv".format(today),
         cybex_queries.csv_get_open_tickets(db, "urgent"),
     )


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR modifies the `create_snapshots_reports_scorecard.py` script so that it produces two additional CSVs:
* `cybex_open_tickets_potentially_risky_services_YYYYMMDD.csv`
* `cybex_closed_tickets_potentially_risky_services_YYYYMMDD.csv`

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This PR depends on https://github.com/cisagov/ncats-webd/pull/33 and is part of the work required for https://github.com/cisagov/cyhy-system/issues/87, which supports [BOD 23-02](https://www.cisa.gov/news-events/directives/binding-operational-directive-23-02).

Related: https://github.com/cisagov/cyhy-mailer/pull/97 to send these new CSVs out.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I confirmed that this code works as expected by making a test script with the same code, which generated the two new CSVs correctly.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##

- [x] Deploy this change to Production.