### PR TITLE
Verify that the snapshot actually contains descendant data

### DIFF
--- a/cyhy_report/customer/generate_report.py
+++ b/cyhy_report/customer/generate_report.py
@@ -2954,7 +2954,7 @@ class ReportGenerator(object):
         # self.__results.  We need to avoid this corner case.
         #
         # See issue #92 for more details.
-        if self.__snapshots[0].get("descendants_included") and "ss0_descendant_data" in self.__results:
+        if "ss0_descendant_data" in self.__results:
             header_fields = (
                 "org_name",
                 "addresses_owned",

--- a/cyhy_report/customer/generate_report.py
+++ b/cyhy_report/customer/generate_report.py
@@ -2947,7 +2947,14 @@ class ReportGenerator(object):
                 data_writer.writerow(row)
 
     def __generate_sub_org_summary_attachment(self):
-        if self.__snapshots[0].get("descendants_included"):
+        # If _all_ the descendants of an org have start dates in the
+        # future (i.e., are not yet scanning) then
+        # self.__snapshots[0].get("descendants_included") will be true
+        # but "ss0_descendant_data" will not be a key of
+        # self.__results.  We need to avoid this corner case.
+        #
+        # See issue #92 for more details.
+        if self.__snapshots[0].get("descendants_included") and "ss0_descendant_data" in self.__results:
             header_fields = (
                 "org_name",
                 "addresses_owned",


### PR DESCRIPTION
## 🗣 Description ##

This pull request fixes an issue where report generation can fail if _all_ the descendants of an org have start dates in the future (i.e., are not yet scanning).

## 💭 Motivation and context ##

Resolves #92.

## 🧪 Testing ##

I made this code change _en vivo_ on our production system and then verified that I was able to successfully create the offending report from #92.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
