### PR TITLE
Improve performance of `create_send_notifications.py`

### DIFF
--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -47,7 +47,7 @@ def build_notifications_org_list(db):
     """Return notifications organization list.
 
     This is the list of organization IDs that should
-    get a notification PDF for CYHY report types.
+    get a notification PDF for CyHy report types.
     """
     notifications_to_generate = set()
     cyhy_parent_ids = set()
@@ -60,14 +60,14 @@ def build_notifications_org_list(db):
     return notifications_to_generate
           
 def find_cyhy_parents(db, org_id):
-    """Find CYHY parents.
+    """Return CyHy parents of an organization.
 
-    Find weekly report types for CYHY parents
-    recursively using the parent IDs.
+    Recursively find all CyHy parents of
+    of an organization using parent IDs.
     """
     cyhy_parents = set()
     for request in db.RequestDoc.collection.find({"children": org_id, "report_types": "CYHY"}, {"_id": 1}):
-        print("Found CYHY Parent of OrgID %s is %s" % (org_id, request["_id"]))
+        print("Found CyHy Parent of OrgID %s is %s" % (org_id, request["_id"]))
         cyhy_parents.add(request["_id"])
         cyhy_parents.update(find_cyhy_parents(db, request["_id"]))
         print("Output of cyhy_parents is: %s " % cyhy_parents)

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -67,14 +67,12 @@ def find_cyhy_parents(db, org_id):
     """
     cyhy_parents = set()
     for request in db.RequestDoc.collection.find({"children": org_id, "report_types": "CYHY"}, {"_id": 1}):
-        print("Found CyHy Parent of OrgID %s is %s" % (org_id, request["_id"]))
         # Found a parent of org_id with "CYHY" in their list of report_types,
         # so add it to our set
         cyhy_parents.add(request["_id"])
         # Recursively call find_cyhy_parents() to check if this org has any parents
         # with "CYHY" in their list of report_types
         cyhy_parents.update(find_cyhy_parents(db, request["_id"]))
-        print("Output of cyhy_parents is: %s " % cyhy_parents)
     return cyhy_parents
 
 

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -51,6 +51,7 @@ def build_notifications_org_list(db):
     notifications_to_generate = set()
     notifications_to_delete = set(ticket_owner_ids) - notifications_to_generate
     cyhy_parent_ids = set()
+    ticket_owner_ids = db.notifications.distinct("ticket_owner")
     for request in db.RequestDoc.collection.find({"_id": {"$in": ticket_owner_ids}, "report_types": "CYHY"}, {"_id":1}):
         # If the notification document's ticket owner has "CYHY" in their list of report_types,
         # then a notification should be generated for that owner:
@@ -60,8 +61,7 @@ def build_notifications_org_list(db):
         # should get a notification.
         cyhy_parent_ids = cyhy_parent_ids | find_cyhy_parents(db, request["_id"])
     notifications_to_generate.update(cyhy_parent_ids)
-    ticket_owner_ids = db.notifications.distinct("ticket_owner")
-    return list(notifications_to_generate), list(notifications_to_delete)
+    return list(notifications_to_generate, notifications_to_delete)
           
 def find_cyhy_parents(db, org_id):
     """Return parents/grandparents/etc. of an organization that have "CYHY" in their list of report_types.

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -75,7 +75,6 @@ def find_cyhy_parents(db, org_id):
         cyhy_parents.update(find_cyhy_parents(db, request["_id"]))
     return cyhy_parents
 
-
 def generate_notification_pdfs(db, org_ids, master_report_key): 
     """Generate all notification PDFs for a list of organizations."""
     num_pdfs_created = 0
@@ -121,9 +120,13 @@ def main():
     # Change to the correct output directory
     os.chdir(os.path.join(NOTIFICATIONS_BASE_DIR, NOTIFICATION_ARCHIVE_DIR))
 
+    # Build list of CyHy orgs
+    notification_org_ids = build_notifications_org_list(db)
+    logging.debug("Found {} CYHY orgs: {}".format(len(notification_org_ids), notification_org_ids))
+
     # Create notification PDFs for CyHy orgs
     master_report_key = Config(args["CYHY_DB_SECTION"]).report_key
-    num_pdfs_created = generate_notification_pdfs(db, cyhy_org_ids, master_report_key)
+    num_pdfs_created = generate_notification_pdfs(db, notification_org_ids, master_report_key)
     logging.info("{} notification PDFs created".format(num_pdfs_created))
 
     # Create a symlink to the latest notifications.  This is for the

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -122,7 +122,7 @@ def main():
     os.chdir(os.path.join(NOTIFICATIONS_BASE_DIR, NOTIFICATION_ARCHIVE_DIR))
 
     # Build list of orgs that should receive notifications
-    notification_org_ids = build_notifications_org_list(db)
+    notification_org_ids, notifications_to_delete = build_notifications_org_list(db)
     logging.debug("Will attempt to generate notifications for {} orgs: {}".format(len(notification_org_ids), notification_org_ids))
 
     # Create notification PDFs for CyHy orgs

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -61,7 +61,7 @@ def build_notifications_org_list(db):
         cyhy_parent_ids = cyhy_parent_ids | find_cyhy_parents(db, request["_id"])
     notifications_to_generate.update(cyhy_parent_ids)
     ticket_owner_ids = db.notifications.distinct("ticket_owner")
-    return list(notifications_to_generate, notifications_to_delete)
+    return list(notifications_to_generate), list(notifications_to_delete)
           
 def find_cyhy_parents(db, org_id):
     """Return parents/grandparents/etc. of an organization that have "CYHY" in their list of report_types.

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -120,9 +120,9 @@ def main():
     # Change to the correct output directory
     os.chdir(os.path.join(NOTIFICATIONS_BASE_DIR, NOTIFICATION_ARCHIVE_DIR))
 
-    # Build list of CyHy orgs
+    # Build list of orgs that should receive notifications
     notification_org_ids = build_notifications_org_list(db)
-    logging.debug("Found {} CYHY orgs: {}".format(len(notification_org_ids), notification_org_ids))
+    logging.debug("Will attempt to generate notifications for {} orgs: {}".format(len(notification_org_ids), notification_org_ids))
 
     # Create notification PDFs for CyHy orgs
     master_report_key = Config(args["CYHY_DB_SECTION"]).report_key

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# comment parts that generate and mail a report
 
 """Create CyHy notifications and email them out to CyHy points of contact.
 

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -70,11 +70,11 @@ def find_cyhy_parents(db, org_id):
     cyhy_parents = set()
     for request in db.RequestDoc.collection.find({"children": org_id}, {"_id": 1, "report_types": 1}):
         if "CYHY" in request["report_types"]:
-            # There is an undocumented constraint where organizations are set up
-            # with only one level of children (i.e. no grandchildren orgs). Given 
-            # the fact that it is undocumented, following the hierarchy to the top
-            # is the best solution. We do not expect to go up more than one level,
-            # but we check all ancestors just to be sure.
+            # There is an undocumented convention at CISA to set up CyHy
+            # organizations with only one level of children (i.e. no
+            # grandchildren orgs). Since it is only a convention and not an
+            # enforced rule, we decided that following the hierarchy to the top
+            # is the safest solution.
             cyhy_parents.add(request["_id"])
             # Found a parent of org_id with "CYHY" in their list of report_types,
             # so add it to our set

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -60,7 +60,7 @@ def build_notifications_org_list(db):
         # should get a notification.
         cyhy_parent_ids = cyhy_parent_ids | find_cyhy_parents(db, request["_id"])
     notifications_to_generate.update(cyhy_parent_ids)
-    return notifications_to_generate
+    return list(notifications_to_generate)
           
 def find_cyhy_parents(db, org_id):
     """Return parents/grandparents/etc. of an organization that have "CYHY" in their list of report_types.

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -53,7 +53,7 @@ def build_notifications_org_list(db):
     ticket_owner_ids = db.notifications.distinct("ticket_owner")
     for request in db.RequestDoc.collection.find({"_id": {"$in": ticket_owner_ids}, "report_types": "CYHY"}, {"_id":1}):
         # If the notification document's ticket owner has "CYHY" in their list of report_types,
-        # then a notification is should be generated for that owner:
+        # then a notification should be generated for that owner:
         notifications_to_generate.add(request["_id"])
         # Recursively check for any parents of the ticket owner that have "CYHY" in
         # their list of report_types.  If found, add them to the list of owners that

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -50,7 +50,7 @@ def build_notifications_org_list(db):
     """
     notifications_to_generate = set()
     cyhy_parent_ids = set()
-    ticket_owner_ids = db.notifications.distinct("ticket_owner")
+    ticket_owner_ids = db.NotificationDoc.collection.distinct("ticket_owner")
     for request in db.RequestDoc.collection.find({"_id": {"$in": ticket_owner_ids}, "report_types": "CYHY"}, {"_id":1}):
         # If the notification document's ticket owner has "CYHY" in their list of report_types,
         # then a notification should be generated for that owner:
@@ -122,12 +122,12 @@ def main():
     os.chdir(os.path.join(NOTIFICATIONS_BASE_DIR, NOTIFICATION_ARCHIVE_DIR))
 
     # Build list of orgs that should receive notifications
-    notification_org_ids, notifications_to_delete = build_notifications_org_list(db)
-    logging.debug("Will attempt to generate notifications for {} orgs: {}".format(len(notification_org_ids), notification_org_ids))
+    notifications_org_ids, notifications_to_delete = build_notifications_org_list(db)
+    logging.debug("Will attempt to generate notifications for {} orgs: {}".format(len(notifications_org_ids), notifications_org_ids))
 
     # Create notification PDFs for CyHy orgs
     master_report_key = Config(args["CYHY_DB_SECTION"]).report_key
-    num_pdfs_created = generate_notification_pdfs(db, notification_org_ids, master_report_key)
+    num_pdfs_created = generate_notification_pdfs(db, notifications_org_ids, master_report_key)
     logging.info("{} notification PDFs created".format(num_pdfs_created))
 
     # Create a symlink to the latest notifications.  This is for the

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -81,7 +81,7 @@ def find_cyhy_parents(db, org_id):
             logging.debug("{} - Adding to set of CYHY parents".format(request["_id"]))
         # Recursively call find_cyhy_parents() to check if this org has any parents
         # with "CYHY" in their list of report_types
-        cyhy_parent_ids = cyhy_parent_ids | find_cyhy_parents(db, request["_id"])
+        cyhy_parent_ids.update(find_cyhy_parents(db, request["_id"]))
     return cyhy_parents
 
 def generate_notification_pdfs(db, org_ids, master_report_key): 

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -49,7 +49,6 @@ def build_notifications_org_list(db):
     have a notification generated and sent.
     """
     notifications_to_generate = set()
-    notifications_to_delete = set(ticket_owner_ids) - notifications_to_generate
     cyhy_parent_ids = set()
     ticket_owner_ids = db.notifications.distinct("ticket_owner")
     for request in db.RequestDoc.collection.find({"_id": {"$in": ticket_owner_ids}, "report_types": "CYHY"}, {"_id":1}):
@@ -61,6 +60,7 @@ def build_notifications_org_list(db):
         # should get a notification.
         cyhy_parent_ids = cyhy_parent_ids | find_cyhy_parents(db, request["_id"])
     notifications_to_generate.update(cyhy_parent_ids)
+    notifications_to_delete = set(ticket_owner_ids) - notifications_to_generate
     return list(notifications_to_generate, notifications_to_delete)
           
 def find_cyhy_parents(db, org_id):

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -61,7 +61,7 @@ def build_notifications_org_list(db):
         cyhy_parent_ids = cyhy_parent_ids | find_cyhy_parents(db, request["_id"])
     notifications_to_generate.update(cyhy_parent_ids)
     notifications_to_delete = set(ticket_owner_ids) - notifications_to_generate
-    return list(notifications_to_generate, notifications_to_delete)
+    return list(notifications_to_generate), list(notifications_to_delete)
           
 def find_cyhy_parents(db, org_id):
     """Return parents/grandparents/etc. of an organization that have "CYHY" in their list of report_types.

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -51,7 +51,6 @@ def build_notifications_org_list(db):
     notifications_to_generate = set()
     notifications_to_delete = set(ticket_owner_ids) - notifications_to_generate
     cyhy_parent_ids = set()
-    ticket_owner_ids = db.notifications.distinct("ticket_owner")
     for request in db.RequestDoc.collection.find({"_id": {"$in": ticket_owner_ids}, "report_types": "CYHY"}, {"_id":1}):
         # If the notification document's ticket owner has "CYHY" in their list of report_types,
         # then a notification should be generated for that owner:
@@ -61,6 +60,7 @@ def build_notifications_org_list(db):
         # should get a notification.
         cyhy_parent_ids = cyhy_parent_ids | find_cyhy_parents(db, request["_id"])
     notifications_to_generate.update(cyhy_parent_ids)
+    ticket_owner_ids = db.notifications.distinct("ticket_owner")
     return list(notifications_to_generate, notifications_to_delete)
           
 def find_cyhy_parents(db, org_id):

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -44,7 +44,7 @@ def create_output_directories():
     )
 
 def build_notifications_org_list(db):
-    """Build notifications organization list.
+    """Return notifications organization list.
 
     This is the list of organization IDs that should
     get a notification PDF for CYHY report types.
@@ -86,7 +86,7 @@ def generate_notification_pdfs(db, org_ids, master_report_key):
         if was_encrypted:
             num_pdfs_created += 1
             logging.info("{} - Created encrypted notification PDF".format(org_id))
-        elif results is not None and len(results["notifications"]) == 0: 
+        elif results is not None and len(results["notifications"]) == 0:
             logging.info("{} - No notifications found, no PDF created".format(org_id))
         else:
             logging.error("{} - Unknown error occurred".format(org_id))

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -73,8 +73,8 @@ def find_cyhy_parents(db, org_id):
             # There is an undocumented constraint where organizations are set up
             # with only one level of children (i.e. no grandchildren orgs). Given 
             # the fact that it is undocumented, following the hierarchy to the top
-            # is the best solution. So we do not exepct to go up more than one level.
-            # However, the implementation above is just a safety measure.
+            # is the best solution. We do not expect to go up more than one level,
+            # but we check all ancestors just to be sure.
             cyhy_parents.add(request["_id"])
             # Found a parent of org_id with "CYHY" in their list of report_types,
             # so add it to our set

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -55,7 +55,7 @@ def build_notifications_org_list(db):
         # If the notification document's ticket owner has "CYHY" in their list of report_types,
         # then a notification should be generated for that owner:
         notifications_to_generate.add(request["_id"])
-        logging.debug("{} - Log request id".format(request["_id"]))
+        logging.debug("Added {} to notifications_to_generate".format(request["_id"]))
         # Recursively check for any ancestors of the ticket owner that have "CYHY" in
         # their list of report_types.  If found, add them to the list of owners that
         # should get a notification.

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -56,7 +56,7 @@ def build_notifications_org_list(db):
         # then a notification should be generated for that owner:
         notifications_to_generate.add(request["_id"])
         logging.debug("{} - Log request id".format(request["_id"]))
-        # Recursively check for any parents of the ticket owner that have "CYHY" in
+        # Recursively check for any ancestors of the ticket owner that have "CYHY" in
         # their list of report_types.  If found, add them to the list of owners that
         # should get a notification.
         cyhy_parent_ids.update(find_cyhy_parents(db, request["_id"]))


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR improves report generation logic, thus speeding up the process significantly as detailed in #94. The number of `report_types: "CYHY"` stakeholders have grown and as such we want to optimize the notification process. This change creates and sends reports only to organizations that require notifications, rather than iterate on the growing list of organizations and blindly calling the notification generator for each organization regardless of whether or not a notification would be generated for that organization.

This process is implemented by checking whether an organization's request document contains "CYHY" in its `report_type` list and whether or not it is a descendant of an organization that contains "CYHY" in its `report_type` list.  This is quicker than iterating over every `report_types: "CYHY"` organization in the database, which is expensive and takes a long time.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Please refer to issue #94 for more information. 

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

These changes were tested by running `extras/create_send_notifications.py` locally in a Docker container, using read-only credentials to the Production database.  The containerized script was scheduled via `cron` to start at the same time as the daily Production notification report generation time (06:00 UTC). The set of notification PDFs generated in Production was then compared with the set of PDFs generated locally to determine if there were any differences. 

All of the same PDFs were generated locally, except for one, when compared to Production.  The reason for that one missing PDF was a timing issue.  The notification document that the PDF was based on was created in the database at 08:00 UTC, well after the local script ended (hence no local PDF was generated), but before the Production script successfully generated a notification PDF for that organization.

The total execution time for local notification PDF generation with these changes was roughly **eight minutes**, which is significantly faster and a huge improvement compared to the Production execution time (without these changes) of **nearly 5 hours**.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [X] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##

- [x] Deploy this change to Production.