### PR TITLE
Fix bug in notification generation logic

### DIFF
--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -139,7 +139,7 @@ def main():
     os.chdir(os.path.join(NOTIFICATIONS_BASE_DIR, NOTIFICATION_ARCHIVE_DIR))
 
     # Build list of orgs that should receive notifications
-    notifications_org_ids, notifications_to_delete = build_notifications_org_list(db)
+    notifications_org_ids, notifications_not_generated = build_notifications_org_list(db)
     logging.debug("Will attempt to generate notifications for {} orgs: {}".format(len(notifications_org_ids), notifications_org_ids))
 
     # Create notification PDFs for CyHy orgs

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -69,6 +69,11 @@ def build_notifications_org_list(db):
 def find_cyhy_parents(db, org_id):
     """Return parents/grandparents/etc. of an organization that have "CYHY" in their list of report_types.
     """
+
+    # WARNING: Even though cyhy-suborg explicitly checks for and blocks stakeholder
+    # cycles, if that guardrail is ever subverted, this function will recursively
+    # overflow and fail.
+ 
     cyhy_parents = set()
     for request in db.RequestDoc.collection.find({"children": org_id}, {"_id": 1, "report_types": 1}):
         if "CYHY" in request["report_types"]:

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -46,9 +46,6 @@ def build_notifications_org_list(db):
     """Return a list of org IDs for which notifications should be
     generated as well as a list of org IDs for which notifications
     should not be generated.
-
-    This is the list of organization IDs that should
-    have a notification generated and sent.
     """
     notifications_to_generate = set()
     cyhy_parent_ids = set()

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -70,10 +70,10 @@ def find_cyhy_parents(db, org_id):
     """Return parents/grandparents/etc. of an organization that have "CYHY" in their list of report_types.
     """
 
-    # WARNING: Even though cyhy-suborg explicitly checks for and blocks stakeholder
-    # cycles, if that guardrail is ever subverted, this function will recursively
-    # overflow and fail.
- 
+    # WARNING: Even though cyhy-suborg explicitly checks for and blocks
+    # stakeholder cycles (e.g. org A is a descendant of org B, which is a
+    # descendant of org A), if that guardrail is ever subverted, this function
+    # will recursively overflow and fail.
     cyhy_parents = set()
     for request in db.RequestDoc.collection.find({"children": org_id}, {"_id": 1, "report_types": 1}):
         if "CYHY" in request["report_types"]:

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -43,7 +43,8 @@ def create_output_directories():
     )
 
 def build_notifications_org_list(db):
-    """Return notifications organization list.
+    """Return list of notifications to generate and 
+       notifications not generated.
 
     This is the list of organization IDs that should
     have a notification generated and sent.

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -60,7 +60,7 @@ def build_notifications_org_list(db):
         # Recursively check for any ancestors of the ticket owner that have "CYHY" in
         # their list of report_types.  If found, add them to the list of owners that
         # should get a notification.
-        logging.debug("{} doesn't have CYHY in report_types; checking parents, grandparents, etc.".format(request["_id"]))
+        logging.debug("Checking for ancestors of {} with CYHY in their list of report_types".format(request["_id"]))
         cyhy_parent_ids.update(find_cyhy_parents(db, request["_id"]))
     notifications_to_generate.update(cyhy_parent_ids)
     notifications_to_delete = set(ticket_owner_ids) - notifications_to_generate
@@ -83,7 +83,7 @@ def find_cyhy_parents(db, org_id):
             logging.debug("{} - Adding to set of CYHY parents".format(request["_id"]))
         # Recursively call find_cyhy_parents() to check if this org has any parents
         # with "CYHY" in their list of report_types
-        logging.debug("{} doesn't have CYHY in report_types; checking parents, grandparents, etc.".format(request["_id"]))
+        logging.debug("Checking for ancestors of {} with CYHY in their list of report_types".format(request["_id"]))
         cyhy_parents.update(find_cyhy_parents(db, request["_id"]))
     return cyhy_parents
 

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -204,7 +204,7 @@ def main():
     # Remove orgs from notifications_to_delete if they are in the list of orgs
     # that we just generated notifications for (most likely because the
     # notification was included in an ancestor org's notification)
-    notifications_not_generated = sorted(set(notifications_to_delete) - set(orgs_notified))
+    notifications_to_delete = sorted(set(notifications_not_generated) - set(orgs_notified))
 
     # Delete NotificationDocs belonging to organizations that we didn't
     # generate notifications for

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -63,8 +63,8 @@ def build_notifications_org_list(db):
         logging.debug("Checking for ancestors of {} with CYHY in their list of report_types".format(request["_id"]))
         cyhy_parent_ids.update(find_cyhy_parents(db, request["_id"]))
     notifications_to_generate.update(cyhy_parent_ids)
-    notifications_to_delete = set(ticket_owner_ids) - notifications_to_generate
-    return sorted(notifications_to_generate), list(notifications_to_delete)
+    notifications_not_generated = set(ticket_owner_ids) - notifications_to_generate
+    return sorted(notifications_to_generate), list(notifications_not_generated)
           
 def find_cyhy_parents(db, org_id):
     """Return parents/grandparents/etc. of an organization that have "CYHY" in their list of report_types.
@@ -204,7 +204,7 @@ def main():
     # Remove orgs from notifications_to_delete if they are in the list of orgs
     # that we just generated notifications for (most likely because the
     # notification was included in an ancestor org's notification)
-    notifications_to_delete = sorted(set(notifications_to_delete) - set(orgs_notified))
+    notifications_not_generated = sorted(set(notifications_to_delete) - set(orgs_notified))
 
     # Delete NotificationDocs belonging to organizations that we didn't
     # generate notifications for

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -64,7 +64,7 @@ def build_notifications_org_list(db):
         cyhy_parent_ids.update(find_cyhy_parents(db, request["_id"]))
     notifications_to_generate.update(cyhy_parent_ids)
     notifications_to_delete = set(ticket_owner_ids) - notifications_to_generate
-    return list(notifications_to_generate), list(notifications_to_delete)
+    return sorted(notifications_to_generate), list(notifications_to_delete)
           
 def find_cyhy_parents(db, org_id):
     """Return parents/grandparents/etc. of an organization that have "CYHY" in their list of report_types.

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -43,8 +43,9 @@ def create_output_directories():
     )
 
 def build_notifications_org_list(db):
-    """Return list of notifications to generate and 
-       notifications not generated.
+    """Return a list of org IDs for which notifications should be
+    generated as well as a list of org IDs for which notifications
+    should not be generated.
 
     This is the list of organization IDs that should
     have a notification generated and sent.

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -53,7 +53,7 @@ def build_notifications_org_list(db):
     ticket_owner_ids = db.NotificationDoc.collection.distinct("ticket_owner")
     for request in db.RequestDoc.collection.find({"_id": {"$in": ticket_owner_ids}}, {"_id": 1, "report_types": 1}):
         if "CYHY" in request["report_types"]:
-            # If the notification document's ticket owner has "CYHY" in their list of report_types,
+            # If the notification document's ticket owner has "CYHY" in its list of report_types,
             # then a notification should be generated for that owner:
             notifications_to_generate.add(request["_id"])
             logging.debug("Added {} to notifications_to_generate".format(request["_id"]))


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR fixes a logic bug that was preventing some parent organizations' notification PDFs from being generated.

It also updates some changes to improve logging (see https://github.com/cisagov/cyhy-reports/pull/104/commits/da0378fc2a27967a3166627b7813793f78713826 and https://github.com/cisagov/cyhy-reports/pull/104/commits/d9c9891d3ebd09ea6076f65a0155a3a3a0949076).

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Today's daily notification generation process did not generate PDFs for certain organizations that should have received them. Specifically, organizations that do receive notification PDFs and that have children that do not. This PR fixes that issue.

The logging change in https://github.com/cisagov/cyhy-reports/pull/104/commits/d9c9891d3ebd09ea6076f65a0155a3a3a0949076 was done because [this log message](https://github.com/cisagov/cyhy-reports/blob/d9c9891d3ebd09ea6076f65a0155a3a3a0949076/extras/create_send_notifications.py#L209-L213) was listing orgs that had notifications included in an ancestor's notification PDF, which was misleading and confusing.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

The cyhy-reports docker image was rebuilt and run locally with these changes and I was able to verify that the missing parent organization notification PDFs that were not present previously now get created. 

This change was sent to Production and is confirmed to also be working. 

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [X] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##

- [x] Deploy this change to Production.