### PR TITLE
Use correct pymongo syntax to determine distinct ticket_owners

### DIFF
--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -186,8 +186,8 @@ def main():
 
         # Determine true list of orgs that just had notifications generated,
         # either directly or via an ancestor org
-        orgs_notified = db.NotificationDoc.collection.distinct(
-            "ticket_owner", {"generated_for": {"$ne": []}})
+        orgs_notified = db.NotificationDoc.collection.find(
+            {"generated_for": {"$ne": []}}).distinct("ticket_owner")
 
         # Delete all NotificationDocs where generated_for is not []
         result = db.NotificationDoc.collection.delete_many(


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This bugfix PR corrects a syntax error that I introduced in #104 (which was ironically also a bugfix PR).

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

When the code from #104 was deployed to Production last night, it ran fine until near the end, when this error was thrown:

```
Dec 13 06:08:22 reporter cyhy-notifications: Traceback (most recent call last):
Dec 13 06:08:22 reporter cyhy-notifications:   File "./create_send_notifications.py", line 225, in <module>
Dec 13 06:08:22 reporter cyhy-notifications:     sys.exit(main())
Dec 13 06:08:22 reporter cyhy-notifications:   File "./create_send_notifications.py", line 190, in main
Dec 13 06:08:22 reporter cyhy-notifications:     "ticket_owner", {"generated_for": {"$ne": []}})
Dec 13 06:08:22 reporter cyhy-notifications: TypeError: distinct() takes exactly 2 arguments (3 given)
```

The notification PDFs were all created and emailed out, but the notification documents in the database were not deleted because of the error above.  To remedy this situation and to prevent any duplicate notifications from being created during the next run of this script, I manually deleted the appropriate notification documents by running this query:
```
> db.notifications.deleteMany({"generated_for": {"$ne": []}})
{ "acknowledged" : true, "deletedCount" : 2205 }
```

I had reviewed the documentation for pymongo `distinct` usage, but I either misread it or was looking at the wrong version of the docs.  Regardless, I should have tested it before including it in #104, so that is my bad.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I verified that this corrected syntax works as intended in a Python interpreter:

```python
In [21]: orgs_notified = db.NotificationDoc.collection.find(
    ...:             {"generated_for": {"$ne": []}}).distinct("ticket_owner")

In [22]: len(orgs_notified)
Out[22]: 94
```

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Deploy this code to Production.
