### PR TITLE
Optimize snapshot and report generation threads in `create_snapshots_reports_scorecard.py`

### DIFF
--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -348,24 +348,21 @@ def generate_weekly_snapshots(db, cyhy_db_section):
         db, reports_to_generate
     )
 
+    logging.debug("%d snapshots to generate: %s", len(snapshots_to_generate), snapshots_to_generate)
+
     # List to keep track of our snapshot creation threads
     snapshot_threads = list()
 
-    # Lists of orgs for each snapshot thread to process
-    snapshots_to_generate = list(
-        make_list_chunks(snapshots_to_generate, SNAPSHOT_THREADS)
-    )
-
     # Start up the threads to create snapshots
-    for orgs in snapshots_to_generate:
+    for t in range(SNAPSHOT_THREADS):
         try:
             snapshot_thread = threading.Thread(
-                target=create_snapshots_from_list, args=(orgs, db, cyhy_db_section),
+                target=create_all_snapshots, args=(db, cyhy_db_section)
             )
             snapshot_threads.append(snapshot_thread)
             snapshot_thread.start()
         except Exception:
-            logging.error("Unable to start snapshot thread for %s", orgs)
+            logging.error("Unable to start snapshot thread #%s", t)
 
     # Wait until each thread terminates
     for snapshot_thread in snapshot_threads:

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -327,9 +327,9 @@ def create_snapshot(db, cyhy_db_section, org_id, use_only_existing_snapshots):
 
 def create_all_snapshots(db, cyhy_db_section):
     """Create a snapshot for each organization in a list."""
+    global snapshots_to_generate
     while True:
         with stg_lock:
-            global snapshots_to_generate
             logging.debug(
                 "[%s] %d snapshot(s) left to generate",
                 threading.current_thread().name,
@@ -520,9 +520,9 @@ def create_report(org_id, cyhy_db_section, scan_db_section, use_docker, nolog):
 
 def create_all_reports(cyhy_db_section, scan_db_section, use_docker, nolog):
     """Create reports for all orgs in a list."""
+    global reports_to_generate
     while True:
         with rtg_lock:
-            global reports_to_generate
             logging.debug(
                 "[%s] %d reports left to generate",
                 threading.current_thread().name,

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -353,7 +353,9 @@ def generate_snapshots_from_list(db, cyhy_db_section):
 
 
 def manage_snapshot_threads(db, cyhy_db_section):
-    """Build the lists of reports and snapshots to be generated, then spawn the
+    """Spawn threads to generate snapshots
+    
+    Build the lists of reports and snapshots to be generated, then spawn the
     threads that generate the snapshots."""
     start_time = time.time()
 

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -15,7 +15,6 @@ Options:
 import distutils.dir_util
 import glob
 import logging
-import math
 import os
 import shutil
 import subprocess

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -315,9 +315,20 @@ def create_snapshot(db, cyhy_db_section, org_id, use_only_existing_snapshots):
     return snapshot_process.returncode
 
 
-def create_snapshots_from_list(org_list, db, cyhy_db_section):
+def create_all_snapshots(db, cyhy_db_section):
     """Create a snapshot for each organization in a list."""
-    for org_id in org_list:
+    while True:
+        with stg_lock:
+            global snapshots_to_generate
+            logging.debug(
+                "[%s] %d snapshot(s) left to generate", threading.current_thread().name, len(snapshots_to_generate))
+            if snapshots_to_generate:
+                org_id = snapshots_to_generate.pop(0)
+            else:
+                logging.info(
+                "[%s] No snapshots left to generate - thread exiting", threading.current_thread().name)
+                break
+
         logging.info(
             "[%s] Starting snapshot for: %s", threading.current_thread().name, org_id
         )

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -338,6 +338,8 @@ def generate_weekly_snapshots(db, cyhy_db_section):
 
     logging.info("Building list of snapshots to generate...")
     global snapshots_to_generate
+    # No thread locking is needed here for snapshots_to_generate because we are
+    # still single-threaded at this point
     snapshots_to_generate = create_list_of_snapshots_to_generate(
         db, reports_to_generate
     )
@@ -912,6 +914,8 @@ def main():
             )
 
         global reports_to_generate
+        # No thread locking is needed here for reports_to_generate because we
+        # are still single-threaded at this point
         if args["--no-snapshots"]:
             # Skip creation of snapshots
             logging.info("Skipping snapshot creation due to --no-snapshots parameter")

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -343,6 +343,7 @@ def generate_weekly_snapshots(db, cyhy_db_section):
     reports_to_generate = create_list_of_reports_to_generate(db)
 
     logging.info("Building list of snapshots to generate...")
+    global snapshots_to_generate
     snapshots_to_generate = create_list_of_snapshots_to_generate(
         db, reports_to_generate
     )

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -496,7 +496,8 @@ def create_report(org_id, cyhy_db_section, scan_db_section, use_docker, nolog):
             )
     data, err = p.communicate()
     report_time = time.time() - report_time
-    report_durations.append((org_id, report_time))
+    with rd_lock:
+        report_durations.append((org_id, report_time))
     return_code = p.returncode
     if return_code == 0:
         logging.info(
@@ -505,7 +506,8 @@ def create_report(org_id, cyhy_db_section, scan_db_section, use_docker, nolog):
             org_id,
             round(report_time, 2),
         )
-        successful_reports.append(org_id)
+        with sr_lock:
+            successful_reports.append(org_id)
     else:
         logging.info(
             "[%s] Failure to generate report: %s",
@@ -518,7 +520,8 @@ def create_report(org_id, cyhy_db_section, scan_db_section, use_docker, nolog):
             data,
             err,
         )
-        failed_reports.append(org_id)
+        with fr_lock:
+            failed_reports.append(org_id)
 
 
 def create_all_reports(cyhy_db_section, scan_db_section, use_docker, nolog):

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -288,24 +288,40 @@ def create_snapshot(db, cyhy_db_section, org_id, use_only_existing_snapshots):
             org_descendants = db.RequestDoc.get_all_descendants(org_id)
 
     if snapshot_process.returncode == 0:
-        logging.info("[%s] Successful snapshot: %s (%.2f s)", threading.current_thread().name, org_id, snapshot_duration)
+        logging.info(
+            "[%s] Successful snapshot: %s (%.2f s)",
+            threading.current_thread().name,
+            org_id,
+            snapshot_duration,
+        )
         with ss_lock:
             successful_snapshots.append(org_id)
             if org_descendants and not use_only_existing_snapshots:
                 logging.info(
-                    "[%s]  - Includes successful descendant snapshot(s): %s", threading.current_thread().name, org_descendants
+                    "[%s]  - Includes successful descendant snapshot(s): %s",
+                    threading.current_thread().name,
+                    org_descendants,
                 )
                 successful_snapshots.extend(org_descendants)
     else:
-        logging.error("[%s] Unsuccessful snapshot: %s", threading.current_thread().name, org_id)
+        logging.error(
+            "[%s] Unsuccessful snapshot: %s", threading.current_thread().name, org_id
+        )
         with fs_lock:
             failed_snapshots.append(org_id)
             if org_descendants and not use_only_existing_snapshots:
                 logging.error(
-                    "[%s]  - Unsuccessful descendant snapshot(s): %s", threading.current_thread().name, org_descendants,
+                    "[%s]  - Unsuccessful descendant snapshot(s): %s",
+                    threading.current_thread().name,
+                    org_descendants,
                 )
                 failed_snapshots.extend(org_descendants)
-        logging.error("[%s] Stderr failure detail: %s %s", threading.current_thread().name, data, err)
+        logging.error(
+            "[%s] Stderr failure detail: %s %s",
+            threading.current_thread().name,
+            data,
+            err,
+        )
     return snapshot_process.returncode
 
 
@@ -315,12 +331,17 @@ def create_all_snapshots(db, cyhy_db_section):
         with stg_lock:
             global snapshots_to_generate
             logging.debug(
-                "[%s] %d snapshot(s) left to generate", threading.current_thread().name, len(snapshots_to_generate))
+                "[%s] %d snapshot(s) left to generate",
+                threading.current_thread().name,
+                len(snapshots_to_generate),
+            )
             if snapshots_to_generate:
                 org_id = snapshots_to_generate.pop(0)
             else:
                 logging.info(
-                "[%s] No snapshots left to generate - thread exiting", threading.current_thread().name)
+                    "[%s] No snapshots left to generate - thread exiting",
+                    threading.current_thread().name,
+                )
                 break
 
         logging.info(
@@ -344,7 +365,11 @@ def generate_weekly_snapshots(db, cyhy_db_section):
         db, reports_to_generate
     )
 
-    logging.debug("%d snapshots to generate: %s", len(snapshots_to_generate), snapshots_to_generate)
+    logging.debug(
+        "%d snapshots to generate: %s",
+        len(snapshots_to_generate),
+        snapshots_to_generate,
+    )
 
     # List to keep track of our snapshot creation threads
     snapshot_threads = list()
@@ -379,7 +404,9 @@ def generate_weekly_snapshots(db, cyhy_db_section):
 def create_report(org_id, cyhy_db_section, scan_db_section, use_docker, nolog):
     """Create a report for a single organization."""
     report_time = time.time()
-    logging.info("[%s] Starting report for: %s", threading.current_thread().name, org_id)
+    logging.info(
+        "[%s] Starting report for: %s", threading.current_thread().name, org_id
+    )
     if use_docker == 1:
         if nolog:
             p = subprocess.Popen(
@@ -497,12 +524,17 @@ def create_all_reports(cyhy_db_section, scan_db_section, use_docker, nolog):
         with rtg_lock:
             global reports_to_generate
             logging.debug(
-                "[%s] %d reports left to generate", threading.current_thread().name, len(reports_to_generate))
+                "[%s] %d reports left to generate",
+                threading.current_thread().name,
+                len(reports_to_generate),
+            )
             if reports_to_generate:
                 org_id = reports_to_generate.pop(0)
             else:
                 logging.info(
-                "[%s] No reports left to generate - exiting", threading.current_thread().name)
+                    "[%s] No reports left to generate - exiting",
+                    threading.current_thread().name,
+                )
                 break
         create_report(org_id, cyhy_db_section, scan_db_section, use_docker, nolog)
 
@@ -524,7 +556,8 @@ def gen_weekly_reports(
     for t in range(REPORT_THREADS):
         try:
             report_thread = threading.Thread(
-                target=create_all_reports, args=(cyhy_db_section, scan_db_section, use_docker, nolog)
+                target=create_all_reports,
+                args=(cyhy_db_section, scan_db_section, use_docker, nolog),
             )
             report_threads.append(report_thread)
             report_thread.start()

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -326,6 +326,7 @@ def generate_snapshot(db, cyhy_db_section, org_id, use_only_existing_snapshots):
 
 def generate_snapshots_from_list(db, cyhy_db_section):
     """Attempt to generate a snapshot for each organization in a global list.
+
     Each thread pulls an organization ID from the global list
     (snapshots_to_generate) and attempts to generate a snapshot for it."""
     global snapshots_to_generate

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -52,6 +52,9 @@ CYHY_REPORT_DIR = os.path.join(
 )
 
 # Global variables and their associated thread locks
+snapshots_to_generate = list()
+stg_lock = threading.Lock()
+
 successful_snapshots = list()
 ss_lock = threading.Lock()
 
@@ -60,6 +63,9 @@ fs_lock = threading.Lock()
 
 snapshot_durations = list()
 sd_lock = threading.Lock()
+
+reports_to_generate = list()
+rtg_lock = threading.Lock()
 
 successful_reports = list()
 sr_lock = threading.Lock()

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -250,12 +250,6 @@ def create_list_of_snapshots_to_generate(db, reports_to_generate):
     return sorted(list(set(reports_to_generate) - report_org_descendants))
 
 
-def make_list_chunks(my_list, num_chunks):
-    """Split a list into a specified number of smaller lists."""
-    for i in range(0, num_chunks):
-        yield my_list[i::num_chunks]
-
-
 def create_snapshot(db, cyhy_db_section, org_id, use_only_existing_snapshots):
     """Create a snapshot for a specified organization."""
     snapshot_start_time = time.time()

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -911,6 +911,7 @@ def main():
                 "No previous CybEx Scorecard JSON file found - continuing without creating CybEx Scorecard"
             )
 
+        global reports_to_generate
         if args["--no-snapshots"]:
             # Skip creation of snapshots
             logging.info("Skipping snapshot creation due to --no-snapshots parameter")

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -294,24 +294,24 @@ def create_snapshot(db, cyhy_db_section, org_id, use_only_existing_snapshots):
             org_descendants = db.RequestDoc.get_all_descendants(org_id)
 
     if snapshot_process.returncode == 0:
-        logging.info("Successful snapshot: %s (%.2f s)", org_id, snapshot_duration)
+        logging.info("[%s] Successful snapshot: %s (%.2f s)", threading.current_thread().name, org_id, snapshot_duration)
         with ss_lock:
             successful_snapshots.append(org_id)
             if org_descendants and not use_only_existing_snapshots:
                 logging.info(
-                    " - Includes successful descendant snapshot(s): %s", org_descendants
+                    "[%s] - Includes successful descendant snapshot(s): %s", threading.current_thread().name, org_descendants
                 )
                 successful_snapshots.extend(org_descendants)
     else:
-        logging.error("Unsuccessful snapshot: %s", org_id)
+        logging.error("[%s] Unsuccessful snapshot: %s", threading.current_thread().name, org_id)
         with fs_lock:
             failed_snapshots.append(org_id)
             if org_descendants and not use_only_existing_snapshots:
                 logging.error(
-                    " - Unsuccessful descendant snapshot(s): %s", org_descendants,
+                    "[%s] - Unsuccessful descendant snapshot(s): %s", threading.current_thread().name, org_descendants,
                 )
                 failed_snapshots.extend(org_descendants)
-        logging.error("Stderr failure detail: %s %s", data, err)
+        logging.error("[%s] Stderr failure detail: %s %s", threading.current_thread().name, data, err)
     return snapshot_process.returncode
 
 

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -293,7 +293,7 @@ def create_snapshot(db, cyhy_db_section, org_id, use_only_existing_snapshots):
             successful_snapshots.append(org_id)
             if org_descendants and not use_only_existing_snapshots:
                 logging.info(
-                    "[%s] - Includes successful descendant snapshot(s): %s", threading.current_thread().name, org_descendants
+                    "[%s]  - Includes successful descendant snapshot(s): %s", threading.current_thread().name, org_descendants
                 )
                 successful_snapshots.extend(org_descendants)
     else:
@@ -302,7 +302,7 @@ def create_snapshot(db, cyhy_db_section, org_id, use_only_existing_snapshots):
             failed_snapshots.append(org_id)
             if org_descendants and not use_only_existing_snapshots:
                 logging.error(
-                    "[%s] - Unsuccessful descendant snapshot(s): %s", threading.current_thread().name, org_descendants,
+                    "[%s]  - Unsuccessful descendant snapshot(s): %s", threading.current_thread().name, org_descendants,
                 )
                 failed_snapshots.extend(org_descendants)
         logging.error("[%s] Stderr failure detail: %s %s", threading.current_thread().name, data, err)


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR gives work to threads more efficiently when creating snapshots and reports in `extras/create_snapshots_reports_scorecard.py`.

Note that this does not include any changes to the way third-party snapshots and reports are generated.  That should be done in a later PR (see issue https://github.com/cisagov/cyhy-reports/issues/60).

I also took this opportunity to improve a few logging statements that did not include the thread name.  This will make the log output easier to understand.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The current code splits the list of snapshots/reports to be generating into a group of sub-lists and assigns each thread one of those sub-lists to work on.  This PR improves upon this by enabling each thread to pull one snapshot or report (to be generated) from a single list and generating it, repeating the process until the list is empty, at which point each thread exits.  This is a more efficient way to utilize the threads.  It should result in a faster overall processing time by preventing some threads from having to generate multiple long-running snapshots/reports, while other threads are sitting idle because they have already completed their work.

This PR resolves #62.  Since I was making related changes here, I also included changes to resolve #59.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I tested this by commenting out or not executing (via switches) parts of the script that were not relevant (e.g. pausing/resuming the commander, creating the sample report, creating third-party snapshots/reports, etc).  Then I temporarily modified the script so that it ran a simple `sleep` command instead of `cyhy-snapshot` and `cyhy-report`.  This allowed me to run the entire script (e.g. `./create_snapshots_reports_scorecard.py --no-dock --no-log --no-pause cyhy-read-only scan-read-only`) and I confirmed that the threading and list consumption worked as intended.

Sample test run output (sanitized and snipped for clarity; note I also limited the number of reports here to generate to 100 for a quicker test run):
```
2024-01-26 10:29:15,075 INFO - BEGIN
2024-01-26 10:29:15,075 INFO - Building list of reports to generate...
2024-01-26 10:29:15,085 INFO - Building list of snapshots to generate...
2024-01-26 10:33:53,529 DEBUG - 100 snapshots to generate: [u'AAA', u'BBB', u'CCC', ...]
2024-01-26 10:33:53,529 DEBUG - [Thread-1] 100 snapshot(s) left to generate
2024-01-26 10:33:53,529 INFO - [Thread-1] Starting snapshot for: AAA
2024-01-26 10:33:53,562 DEBUG - [Thread-2] 99 snapshot(s) left to generate
2024-01-26 10:33:53,563 INFO - [Thread-2] Starting snapshot for: BBB
2024-01-26 10:33:53,563 DEBUG - [Thread-3] 98 snapshot(s) left to generate
2024-01-26 10:33:53,564 INFO - [Thread-3] Starting snapshot for: CCC
...
2024-01-26 10:33:54,603 INFO - [Thread-1] Successful snapshot: AAA (1.06 s)
2024-01-26 10:33:54,604 DEBUG - [Thread-1] 68 snapshot(s) left to generate
2024-01-26 10:33:54,605 INFO - [Thread-1] Starting snapshot for: YYY
2024-01-26 10:33:54,645 INFO - [Thread-3] Successful snapshot: CCC (1.04 s)
2024-01-26 10:33:54,699 INFO - [Thread-2] Successful snapshot: BBB (1.03 s)
...
2024-01-26 10:33:59,814 INFO - [Thread-1] Successful snapshot: ZZZ (2.04 s)
2024-01-26 10:33:59,814 DEBUG - [Thread-1] 0 snapshot(s) left to generate
2024-01-26 10:33:59,814 INFO - [Thread-1] No snapshots left to generate - thread exiting
...
2024-01-26 10:34:00,023 INFO - Time to complete snapshots: 4.75 minutes
2024-01-26 10:34:00,024 INFO - Longest Snapshots:
2024-01-26 10:34:00,024 INFO - GGG: 2.1 seconds
2024-01-26 10:34:00,025 INFO - HHH: 2.1 seconds
2024-01-26 10:34:00,025 INFO - MMM: 2.1 seconds
...
2024-01-26 10:34:00,026 DEBUG - 100 reports to generate: [u'AAA', u'BBB', u'CCC', ...]
2024-01-26 10:34:00,027 DEBUG - [Thread-33] 100 reports left to generate
2024-01-26 10:34:00,027 INFO - [Thread-33] Starting report for: AAA
2024-01-26 10:34:00,533 DEBUG - [Thread-34] 99 reports left to generate
2024-01-26 10:34:00,534 INFO - [Thread-34] Starting report for: BBB
2024-01-26 10:34:01,037 DEBUG - [Thread-35] 98 reports left to generate
2024-01-26 10:34:01,038 INFO - [Thread-35] Starting report for: CCC
2024-01-26 10:34:01,071 INFO - [Thread-33] Successful report generated: AAA (1.04 s)
2024-01-26 10:34:01,071 DEBUG - [Thread-33] 97 reports left to generate
2024-01-26 10:34:01,071 INFO - [Thread-33] Starting report for: FFF
...
2024-01-26 10:34:02,108 INFO - [Thread-33] Successful report generated: FFF (1.04 s)
2024-01-26 10:34:02,109 DEBUG - [Thread-33] 94 reports left to generate
2024-01-26 10:34:02,109 INFO - [Thread-33] Starting report for: JJJ
2024-01-26 10:34:02,582 INFO - [Thread-34] Successful report generated: BBB (2.05 s)
2024-01-26 10:34:02,583 DEBUG - [Thread-34] 92 reports left to generate
2024-01-26 10:34:02,583 INFO - [Thread-34] Starting report for: NNN
...
2024-01-26 10:34:03,086 INFO - [Thread-35] Successful report generated: CCC (2.05 s)
2024-01-26 10:34:03,087 DEBUG - [Thread-35] 89 reports left to generate
2024-01-26 10:34:03,087 INFO - [Thread-35] Starting report for: PPP
...
2024-01-26 10:34:14,273 INFO - [Thread-47] Successful report generated: ZZZ (2.03 s)
2024-01-26 10:34:14,273 DEBUG - [Thread-47] 0 reports left to generate
2024-01-26 10:34:14,273 INFO - [Thread-47] No reports left to generate - exiting
2024-01-26 10:34:14,274 INFO - Time to complete reports: 0.24 minutes
2024-01-26 10:34:14,274 INFO - Longest Reports:
2024-01-26 10:34:14,274 INFO - QQQ: 2.1 seconds
2024-01-26 10:34:14,274 INFO - TTT: 2.1 seconds
2024-01-26 10:34:14,274 INFO - VVV: 2.1 seconds
...
2024-01-26 10:34:14,275 INFO - Time to complete reports: 0.24 minutes
2024-01-26 10:34:14,275 INFO - Number of snapshots generated: 115
2024-01-26 10:34:14,276 INFO -   Third-party snapshots generated: 0
2024-01-26 10:34:14,276 INFO - Number of snapshots failed: 0
2024-01-26 10:34:14,276 INFO -   Third-party snapshots failed: 0
2024-01-26 10:34:14,276 INFO - Number of reports generated: 100
2024-01-26 10:34:14,276 INFO -   Third-party reports generated: 0
2024-01-26 10:34:14,277 INFO - Number of reports failed: 0
2024-01-26 10:34:14,277 INFO -   Third-party reports failed: 0
2024-01-26 10:34:14,277 INFO - Total time: 4.99 minutes
2024-01-26 10:34:14,277 INFO - END
```

I also ran a test against the entire Production set of orgs and confirmed that everything worked fine (from a thread and work consumption standpoint) with a larger set of snapshots and reports.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Deploy the updated script to Production.
- [x] Validate that the updated script runs successfully in Production.
