### PR TITLE
Increase "waiting for commander to pause" timeout in `create_snapshots_reports_scorecard.py`

### DIFF
--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -576,7 +576,7 @@ def sync_all_tallies(db):
 
 def pause_commander(db):
     # number of iterations to wait before giving up
-    PAUSE_ITERATION_LIMIT = 30
+    PAUSE_ITERATION_LIMIT = 90
 
     # number of seconds to wait between each check to see
     # if the commander has paused


### PR DESCRIPTION


# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR increases the "commander pause" waiting timeout period in the `create_snapshots_reports_scorecard.py` script from 30 minutes to 90 minutes.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

As the volume of CyHy stakeholders has grown, commander loop cycles have increased in duration, to the point where it can take longer than 30 minutes for the commander to complete a loop and pause.

This change was already deployed in Production several weeks ago, so this PR gets our code in sync.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

This change has been running in Production for several reporting cycles without any issues.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
