### PR TITLE
Bump up the number of report threads

### DIFF
--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -40,8 +40,8 @@ current_time = util.utcnow()
 
 LOGGING_LEVEL = logging.INFO
 LOG_FILE = "snapshots_reports_scorecard_automation.log"
-REPORT_THREADS = 18
-SNAPSHOT_THREADS = 32
+REPORT_THREADS = 40
+SNAPSHOT_THREADS = 40
 
 NCATS_DHUB_URL = "dhub.ncats.cyber.dhs.gov:5001"
 NCATS_WEB_URL = "web.data.ncats.cyber.dhs.gov"

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -44,7 +44,6 @@ REPORT_THREADS = 40
 SNAPSHOT_THREADS = 40
 
 NCATS_DHUB_URL = "dhub.ncats.cyber.dhs.gov:5001"
-NCATS_WEB_URL = "web.data.ncats.cyber.dhs.gov"
 
 WEEKLY_REPORT_BASE_DIR = "/var/cyhy/reports/output"
 SCORECARD_OUTPUT_DIR = "scorecards"


### PR DESCRIPTION
## 🗣 Description ##

This pull request bumps up the number of report threads as well as the number of snapshot threads.  Both are bumped up to 40, a value we arrived at after a lot of trial and error.
See the comments in this pull request for more details.

## 💭 Motivation and context ##

This change is being made to speed up the CyHy reporting process.  This change has already been made in production, so it is a good idea to ensure that the code in GitHub is updated as well.

## 🧪 Testing ##

We did a complete CyHy reporting run with these changes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.