### PR TITLE
Log additional performance metrics in `create_snapshots_reports_scorecard.py`

### DIFF
--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -15,7 +15,6 @@ Options:
 import distutils.dir_util
 import glob
 import logging
-import numpy
 import os
 import shutil
 import subprocess
@@ -26,6 +25,7 @@ import time
 from bson import ObjectId
 from collections import defaultdict
 from docopt import docopt
+import numpy
 
 from cyhy.core import SCAN_TYPE
 from cyhy.core.common import REPORT_TYPE, REPORT_PERIOD

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -398,11 +398,6 @@ def manage_snapshot_threads(db, cyhy_db_section):
         "Time to complete snapshots: %.2f minutes", (time.time() - start_time) / 60
     )
 
-    snapshot_durations.sort(key=lambda tup: tup[1], reverse=True)
-    logging.info("Longest Snapshots:")
-    for i in snapshot_durations[:10]:
-        logging.info("%s: %.1f seconds", i[0], i[1])
-
     reports_to_generate = set(reports_to_generate) - set(failed_snapshots)
     return sorted(list(reports_to_generate))
 
@@ -543,11 +538,6 @@ def manage_report_threads(cyhy_db_section, scan_db_section, use_docker, nolog):
     logging.info(
         "Time to complete reports: %.2f minutes", (time.time() - start_time) / 60
     )
-
-    report_durations.sort(key=lambda tup: tup[1], reverse=True)
-    logging.info("Longest Reports:")
-    for i in report_durations[:10]:
-        logging.info("%s: %.1f seconds", i[0], i[1])
 
     # Create a symlink to the latest reports.  This is for the
     # automated sending of reports.
@@ -1034,6 +1024,11 @@ def main():
             min = numpy.min(durations)
             logging.info("  Minimum snapshot: %.1f seconds (%.1f minutes)", min, min / 60)
 
+            snapshot_durations.sort(key=lambda tup: tup[1], reverse=True)
+            logging.info("Longest snapshots:")
+            for i in snapshot_durations[:10]:
+                logging.info("  %s: %.1f seconds (%.1f minutes)", i[0], i[1], i[1] / 60)
+
         logging.info("Report performance:")
         durations = [x[1] for x in report_durations]
         max = numpy.max(durations)
@@ -1044,6 +1039,11 @@ def main():
         logging.info("  Mean report: %.1f seconds (%.1f minutes)", mean, mean / 60)
         min = numpy.min(durations)
         logging.info("  Minimum report: %.1f seconds (%.1f minutes)", min, min / 60)
+
+        report_durations.sort(key=lambda tup: tup[1], reverse=True)
+        logging.info("Longest reports:")
+        for i in report_durations[:10]:
+            logging.info("  %s: %.1f seconds (%.1f minutes)", i[0], i[1], i[1] / 60)
 
         logging.info("Total time: %.2f minutes", (time.time() - start_time) / 60)
         logging.info("END\n\n")

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -1016,13 +1016,13 @@ def main():
             logging.info("Snapshot performance:")
             durations = [x[1] for x in snapshot_durations]
             max = numpy.max(durations)
-            logging.info("  Maximum snapshot: %.1f seconds (%.1f minutes)", max, max / 60)
+            logging.info("  Longest snapshot: %.1f seconds (%.1f minutes)", max, max / 60)
             median = numpy.median(durations)
             logging.info("  Median snapshot: %.1f seconds (%.1f minutes)", median, median / 60)
             mean = numpy.mean(durations)
             logging.info("  Mean snapshot: %.1f seconds (%.1f minutes)", mean, mean / 60)
             min = numpy.min(durations)
-            logging.info("  Minimum snapshot: %.1f seconds (%.1f minutes)", min, min / 60)
+            logging.info("  Shortest snapshot: %.1f seconds (%.1f minutes)", min, min / 60)
 
             snapshot_durations.sort(key=lambda tup: tup[1], reverse=True)
             logging.info("Longest snapshots:")
@@ -1032,13 +1032,13 @@ def main():
         logging.info("Report performance:")
         durations = [x[1] for x in report_durations]
         max = numpy.max(durations)
-        logging.info("  Maximum report: %.1f seconds (%.1f minutes)", max, max / 60)
+        logging.info("  Longest report: %.1f seconds (%.1f minutes)", max, max / 60)
         median = numpy.median(durations)
         logging.info("  Median report: %.1f seconds (%.1f minutes)", median, median / 60)
         mean = numpy.mean(durations)
         logging.info("  Mean report: %.1f seconds (%.1f minutes)", mean, mean / 60)
         min = numpy.min(durations)
-        logging.info("  Minimum report: %.1f seconds (%.1f minutes)", min, min / 60)
+        logging.info("  Shortest report: %.1f seconds (%.1f minutes)", min, min / 60)
 
         report_durations.sort(key=lambda tup: tup[1], reverse=True)
         logging.info("Longest reports:")

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -15,6 +15,7 @@ Options:
 import distutils.dir_util
 import glob
 import logging
+import numpy
 import os
 import shutil
 import subprocess
@@ -1020,6 +1021,29 @@ def main():
                     logging.error("%s (third-party)", i)
                 else:
                     logging.error(i)
+
+        if not args["--no-snapshots"]:
+            logging.info("Snapshot performance:")
+            durations = [x[1] for x in snapshot_durations]
+            max = numpy.max(durations)
+            logging.info("  Maximum snapshot: %.1f seconds (%.1f minutes)", max, max / 60)
+            median = numpy.median(durations)
+            logging.info("  Median snapshot: %.1f seconds (%.1f minutes)", median, median / 60)
+            mean = numpy.mean(durations)
+            logging.info("  Mean snapshot: %.1f seconds (%.1f minutes)", mean, mean / 60)
+            min = numpy.min(durations)
+            logging.info("  Minimum snapshot: %.1f seconds (%.1f minutes)", min, min / 60)
+
+        logging.info("Report performance:")
+        durations = [x[1] for x in report_durations]
+        max = numpy.max(durations)
+        logging.info("  Maximum report: %.1f seconds (%.1f minutes)", max, max / 60)
+        median = numpy.median(durations)
+        logging.info("  Median report: %.1f seconds (%.1f minutes)", median, median / 60)
+        mean = numpy.mean(durations)
+        logging.info("  Mean report: %.1f seconds (%.1f minutes)", mean, mean / 60)
+        min = numpy.min(durations)
+        logging.info("  Minimum report: %.1f seconds (%.1f minutes)", min, min / 60)
 
         logging.info("Total time: %.2f minutes", (time.time() - start_time) / 60)
         logging.info("END\n\n")

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -12,6 +12,7 @@ Options:
   --no-pause            do not pause the commander when generating reports
 """
 
+# Standard Python Libraries
 import distutils.dir_util
 import glob
 import logging
@@ -22,11 +23,13 @@ import sys
 import threading
 import time
 
+# Third-Party Libraries
 from bson import ObjectId
 from collections import defaultdict
 from docopt import docopt
 import numpy
 
+# cisagov Libraries
 from cyhy.core import SCAN_TYPE
 from cyhy.core.common import REPORT_TYPE, REPORT_PERIOD
 from cyhy.db import database, CHDatabase


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds additional performance metrics to the logging of `extras/create_snapshots_reports_scorecard.py`:
 * Maximum, median, mean, minimum snapshot-generation duration
 * Maximum, median, mean, minimum report-generation duration

I also took this opportunity to relocate some existing logging (top-10 longest snapshots and reports) to the end of the script, where it can be more easily parsed along with the new output listed above (see https://github.com/cisagov/cyhy-reports/commit/965dca651f6d7d03f032519b333dc1c7a06bbee2).

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Having this additional information will be useful as we adjust our parallelization (thread count) settings in order to find our optimal configuration.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I stubbed out any non-relevant code in `create_snapshots_reports_scorecard.py` and used a `sleep` command (with a random duration) instead of generating snapshots and reports.  This allowed me to run the script without affecting any data.  I confirmed that output like this was logged:

```console
2024-03-20 15:40:09,444 INFO - Snapshot performance:
2024-03-20 15:40:09,445 INFO -   Maximum snapshot: 10.0 seconds (0.2 minutes)
2024-03-20 15:40:09,447 INFO -   Median snapshot: 6.0 seconds (0.1 minutes)
2024-03-20 15:40:09,447 INFO -   Mean snapshot: 6.0 seconds (0.1 minutes)
2024-03-20 15:40:09,448 INFO -   Minimum snapshot: 1.0 seconds (0.0 minutes)
2024-03-20 15:40:09,448 INFO - Longest snapshots:
2024-03-20 15:40:09,448 INFO -   AAA: 10.0 seconds (0.2 minutes)
2024-03-20 15:40:09,448 INFO -   BBB: 10.0 seconds (0.2 minutes)
2024-03-20 15:40:09,448 INFO -   CCC: 10.0 seconds (0.2 minutes)
2024-03-20 15:40:09,448 INFO -   DDD: 10.0 seconds (0.2 minutes)
2024-03-20 15:40:09,449 INFO -   EEE: 10.0 seconds (0.2 minutes)
2024-03-20 15:40:09,449 INFO -   FFF: 10.0 seconds (0.2 minutes)
2024-03-20 15:40:09,449 INFO -   GGG: 10.0 seconds (0.2 minutes)
2024-03-20 15:40:09,449 INFO -   HHH: 10.0 seconds (0.2 minutes)
2024-03-20 15:40:09,449 INFO -   III: 10.0 seconds (0.2 minutes)
2024-03-20 15:40:09,449 INFO -   JJJ: 10.0 seconds (0.2 minutes)
2024-03-20 15:40:09,449 INFO - Report performance:
2024-03-20 15:40:09,450 INFO -   Maximum report: 7.0 seconds (0.1 minutes)
2024-03-20 15:40:09,450 INFO -   Median report: 4.0 seconds (0.1 minutes)
2024-03-20 15:40:09,450 INFO -   Mean report: 4.2 seconds (0.1 minutes)
2024-03-20 15:40:09,450 INFO -   Minimum report: 1.0 seconds (0.0 minutes)
2024-03-20 15:40:09,450 INFO - Longest reports:
2024-03-20 15:40:09,450 INFO -   LLL: 7.0 seconds (0.1 minutes)
2024-03-20 15:40:09,451 INFO -   MMM: 7.0 seconds (0.1 minutes)
2024-03-20 15:40:09,451 INFO -   NNN: 7.0 seconds (0.1 minutes)
2024-03-20 15:40:09,451 INFO -   OOO: 7.0 seconds (0.1 minutes)
2024-03-20 15:40:09,451 INFO -   PPP: 7.0 seconds (0.1 minutes)
2024-03-20 15:40:09,451 INFO -   QQQ: 7.0 seconds (0.1 minutes)
2024-03-20 15:40:09,451 INFO -   RRR: 7.0 seconds (0.1 minutes)
2024-03-20 15:40:09,451 INFO -   SSS: 7.0 seconds (0.1 minutes)
2024-03-20 15:40:09,451 INFO -   TTT: 7.0 seconds (0.1 minutes)
2024-03-20 15:40:09,451 INFO -   UUU: 7.0 seconds (0.1 minutes)
```

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Deploy these changes to Production.
