### PR TITLE
Only display duration in "Longest snapshots/reports" summary for successful snapshots/report

### DIFF
--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -336,10 +336,11 @@ def generate_snapshot(db, cyhy_db_section, org_id, third_party):
                     successful_snapshots.extend(org_descendants)
     else:
         logging.error(
-            "[%s] Unsuccessful %ssnapshot: %s",
+            "[%s] Unsuccessful %ssnapshot: %s (%.2f s)",
             threading.current_thread().name,
             "third-party " if third_party else "",
             org_id,
+            snapshot_duration,
         )
         with fs_lock:
             if third_party:
@@ -644,10 +645,11 @@ def generate_report(org_id, cyhy_db_section, scan_db_section, use_docker, nolog,
                 successful_reports.append(org_id)
     else:
         logging.info(
-            "[%s] Failure to generate %sreport: %s",
+            "[%s] Failure to generate %sreport: %s (%.2f s)",
             threading.current_thread().name,
             "third-party " if third_party else "",
             org_id,
+            report_duration,
         )
         logging.info(
             "[%s] Stderr report detail: %s%s",

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -294,12 +294,6 @@ def generate_snapshot(db, cyhy_db_section, org_id, third_party):
 
     snapshot_duration = time.time() - snapshot_start_time
 
-    with sd_lock:
-        if third_party:
-            tp_snapshot_durations.append((org_id, snapshot_duration))
-        else:
-            snapshot_durations.append((org_id, snapshot_duration))
-
     # Determine org's descendants for logging below
     org_descendants = list()
     # Third-party snapshots are based on descendant snapshots that already
@@ -323,6 +317,11 @@ def generate_snapshot(db, cyhy_db_section, org_id, third_party):
             org_id,
             snapshot_duration,
         )
+        with sd_lock:
+            if third_party:
+                tp_snapshot_durations.append((org_id, snapshot_duration))
+            else:
+                snapshot_durations.append((org_id, snapshot_duration))
         with ss_lock:
             if third_party:
                 successful_tp_snapshots.append(org_id)
@@ -624,11 +623,6 @@ def generate_report(org_id, cyhy_db_section, scan_db_section, use_docker, nolog,
     data, err = report_process.communicate()
 
     report_duration = time.time() - report_start_time
-    with rd_lock:
-        if third_party:
-            tp_report_durations.append((org_id, report_duration))
-        else:
-            report_durations.append((org_id, report_duration))
 
     if report_process.returncode == 0:
         logging.info(
@@ -638,6 +632,11 @@ def generate_report(org_id, cyhy_db_section, scan_db_section, use_docker, nolog,
             org_id,
             round(report_duration, 2),
         )
+        with rd_lock:
+            if third_party:
+                tp_report_durations.append((org_id, report_duration))
+            else:
+                report_durations.append((org_id, report_duration))
         with sr_lock:
             if third_party:
                 successful_tp_reports.append(org_id)

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -627,11 +627,11 @@ def generate_report(org_id, cyhy_db_section, scan_db_section, use_docker, nolog,
 
     if report_process.returncode == 0:
         logging.info(
-            "[%s] Successful %sreport generated: %s (%.2f s)",
+            "[%s] Successful %sreport: %s (%.2f s)",
             threading.current_thread().name,
             "third-party " if third_party else "",
             org_id,
-            round(report_duration, 2),
+            report_duration,
         )
         with rd_lock:
             if third_party:
@@ -645,7 +645,7 @@ def generate_report(org_id, cyhy_db_section, scan_db_section, use_docker, nolog,
                 successful_reports.append(org_id)
     else:
         logging.info(
-            "[%s] Failure to generate %sreport: %s (%.2f s)",
+            "[%s] Unsuccessful %sreport: %s (%.2f s)",
             threading.current_thread().name,
             "third-party " if third_party else "",
             org_id,


### PR DESCRIPTION


# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR modifies the logic in `create_snapshots_reports_scorecard.py` so that the duration is only displayed in the "Longest snapshots" and "Longest reports" summary at the end of the script if the snapshot/report was generated successfully.

Additionally:
* To ensure that the durations of failed snapshots or reports are still easily obtained, https://github.com/cisagov/cyhy-reports/commit/d46f558a450abde397bd0d1119b6c6d952f6d0ab adds those failure durations to logging output.
* https://github.com/cisagov/cyhy-reports/commit/2df8a08b8d55f72373b6ee13bbb40f46cb1313a5 modifies the report logging verbiage so that it is consistent with the logging for snapshots.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

In the event that a snapshot/report fails to generate, but then succeeds on the retry attempt, it is confusing to have two durations listed for that action in the "Longest snapshots" and "Longest reports" summary at the end of the script.  It makes more sense to only display the durations of successful attempts there.

Resolves #120.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I tested this PR by running a stripped-down and read-only version of `create_snapshots_reports_scorecard.py` (see the testing section of #119 for details).  I was able to confirm that in cases where a snapshot or report failed and then was generated successfully by the retry, the successful duration was displayed in the summary at the end of the script and the failed duration was not.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Deploy this change to Production.
