### PR TITLE
Trim long finding descriptions in the customer report

### DIFF
--- a/cyhy_report/customer/generate_report.py
+++ b/cyhy_report/customer/generate_report.py
@@ -3432,6 +3432,18 @@ class ReportGenerator(object):
             t["first_detected_time_tex"] = t["first_detected"].strftime("{%H}{%M}{%S}")
             t["last_detected_date_tex"] = t["last_detected"].strftime("{%d}{%m}{%Y}")
             t["last_detected_time_tex"] = t["last_detected"].strftime("{%H}{%M}{%S}")
+            # Trim long descriptions so that they don't overflow the page
+            # (LaTeX table cells cannot span pages, as far as I know) or cause
+            # other issues. For more information, see:
+            # - https://github.com/cisagov/cyhy-reports/issues/124
+            # - https://github.com/cisagov/cyhy-reports/issues/123
+            # NOTE: I wanted to make the cutoff 4096 characters, but that barely
+            # fit on a single page when there was a single affected host.  I
+            # went with 3072 instead to save space on the page for when there
+            # are many affected hosts listed.
+            if len(t["description"]) > 3072:
+                t["description"] = t["description"][:3072] + \
+                    "... (Truncated; the full description is available in the findings attachment.)"
 
         result["mitigations"] = self.__results["mitigations"]
         for t in result["mitigations"]:

--- a/cyhy_report/customer/generate_report.py
+++ b/cyhy_report/customer/generate_report.py
@@ -3440,8 +3440,8 @@ class ReportGenerator(object):
             # Trim long descriptions so that they don't overflow the page
             # (LaTeX table cells cannot span pages, as far as I know) or cause
             # other issues. For more information, see:
-            # - https://github.com/cisagov/cyhy-reports/issues/124
             # - https://github.com/cisagov/cyhy-reports/issues/123
+            # - https://github.com/cisagov/cyhy-reports/issues/124
             if len(t["description"]) > FINDING_DESCRIPTION_MAX_DISPLAY_LENGTH:
                 t["description"] = t["description"][
                     :FINDING_DESCRIPTION_MAX_DISPLAY_LENGTH] + \

--- a/cyhy_report/customer/generate_report.py
+++ b/cyhy_report/customer/generate_report.py
@@ -190,6 +190,11 @@ POTENTIAL_NMI_SERVICES = [
     "telnet",         # Telnet
 ]
 
+# I wanted to make the cutoff 4096 characters, but that barely fit on a single
+# page when there was a single affected host.  I went with 3072 instead to save
+# space on the page for when there are many affected hosts listed.
+FINDING_DESCRIPTION_MAX_DISPLAY_LENGTH = 3072
+
 def SafeDataFrame(data=None, *args, **kwargs):
     """A wrapper around pandas DataFrame so that empty lists still
     return a DataFrame with columns if requested."""
@@ -3437,12 +3442,9 @@ class ReportGenerator(object):
             # other issues. For more information, see:
             # - https://github.com/cisagov/cyhy-reports/issues/124
             # - https://github.com/cisagov/cyhy-reports/issues/123
-            # NOTE: I wanted to make the cutoff 4096 characters, but that barely
-            # fit on a single page when there was a single affected host.  I
-            # went with 3072 instead to save space on the page for when there
-            # are many affected hosts listed.
-            if len(t["description"]) > 3072:
-                t["description"] = t["description"][:3072] + \
+            if len(t["description"]) > FINDING_DESCRIPTION_MAX_DISPLAY_LENGTH:
+                t["description"] = t["description"][
+                    :FINDING_DESCRIPTION_MAX_DISPLAY_LENGTH] + \
                     "... (Truncated; the full description is available in the findings attachment.)"
 
         result["mitigations"] = self.__results["mitigations"]


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR modifies the [CyHy customer report](https://github.com/cisagov/cyhy-reports/tree/develop/cyhy_report/customer) so that long finding descriptions (more than 3,072 characters) are trimmed when they are displayed in "Appendix C: Detailed Findings and Recommended Mitigations by Vulnerability".

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This is being done so that long finding descriptions don't overflow the page (LaTeX table cells cannot span pages, as far as I know) or cause other issues such as the one documented in https://github.com/cisagov/cyhy-reports/issues/123.

Resolves #124 and resolves #123.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

To test this PR, I selected a CyHy entity that had a few findings, but not too many (so that I could generate their reports relatively quickly).  Then, I manually modified one of their findings to have a long description (over 5,000 characters).  When I generated a test report for that entity, I confirmed that:
- The long finding description was indeed truncated.
- The full finding description (not truncated) was present in `findings.csv`.
- No other finding descriptions were being truncated.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📷 Screenshot ##

An example of a test report containing a truncated (placeholder text) description:
<img width="1088" alt="Screenshot 2024-06-05 at 1 27 11 PM" src="https://github.com/cisagov/cyhy-reports/assets/21343441/3745ebaa-3a6b-4e42-8cd6-b2bd9ac503b8">


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Revert modified finding description back to its original state.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Deploy this change to Production.