### PR TITLE
Bump up the numbers of snapshot and report threads

### DIFF
--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -40,8 +40,8 @@ current_time = util.utcnow()
 
 LOGGING_LEVEL = logging.INFO
 LOG_FILE = "snapshots_reports_scorecard_automation.log"
-REPORT_THREADS = 40
-SNAPSHOT_THREADS = 40
+REPORT_THREADS = 70
+SNAPSHOT_THREADS = 70
 
 NCATS_DHUB_URL = "dhub.ncats.cyber.dhs.gov:5001"
 

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -40,8 +40,8 @@ current_time = util.utcnow()
 
 LOGGING_LEVEL = logging.INFO
 LOG_FILE = "snapshots_reports_scorecard_automation.log"
-REPORT_THREADS = 70
-SNAPSHOT_THREADS = 70
+REPORT_THREADS = 72  # Match the number of available CPUs on the reporter instance
+SNAPSHOT_THREADS = 80
 
 NCATS_DHUB_URL = "dhub.ncats.cyber.dhs.gov:5001"
 

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -40,12 +40,19 @@ current_time = util.utcnow()
 
 LOGGING_LEVEL = logging.INFO
 LOG_FILE = "snapshots_reports_scorecard_automation.log"
-# 11/5/2025 - There are 96 available CPUs on the reporter instance.
-# With 80 snapshot threads we are generating all our snapshots in about
-# 20 minutes; with 72 report threads we are generating all our reports
-# in about two hours.  Given this vast speed increase, we can afford to
-# be conservative and not try increasing the numbers of threads further
-# for now.
+# 11/5/2025 - There are 72 available CPUs on the reporter instance, so
+# we are matching the number of reporter threads with the number of CPUs
+# on the reporter instance.  (Report throughput is primarily dependent
+# on the CPU power of the reporter instance.)  With 72 report threads we
+# are generating all our reports in about two hours.
+#
+# There are 96 available CPUs on the database instance.  With 80
+# snapshot threads we are generating all our snapshots in about 20
+# minutes.  (Snapshot throughput is primarily dependent on the CPU power
+# of the database instance.)
+#
+# Given these vast speed increases, we can afford to be conservative and
+# not try increasing the numbers of threads further for now.
 REPORT_THREADS = 72
 SNAPSHOT_THREADS = 80
 

--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -40,7 +40,13 @@ current_time = util.utcnow()
 
 LOGGING_LEVEL = logging.INFO
 LOG_FILE = "snapshots_reports_scorecard_automation.log"
-REPORT_THREADS = 72  # Match the number of available CPUs on the reporter instance
+# 11/5/2025 - There are 96 available CPUs on the reporter instance.
+# With 80 snapshot threads we are generating all our snapshots in about
+# 20 minutes; with 72 report threads we are generating all our reports
+# in about two hours.  Given this vast speed increase, we can afford to
+# be conservative and not try increasing the numbers of threads further
+# for now.
+REPORT_THREADS = 72
 SNAPSHOT_THREADS = 80
 
 NCATS_DHUB_URL = "dhub.ncats.cyber.dhs.gov:5001"

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ extra_files = package_files("cyhy_report/assets")
 
 setup(
     name="cyhy-reports",
-    version="1.1.0",
+    version="1.1.1",
     author="Mark Feldhousen Jr.",
     author_email="mark.feldhousen@hq.dhs.gov",
     packages=[


### PR DESCRIPTION
## 🗣 Description ##

This pull request bumps up the numbers of snapshot and report threads.

> [!NOTE]
> We are still working to determine the optimum number of threads.  This pull request should not be merged until that work is finalized.

## 💭 Motivation and context ##

We are using a larger instance type now (see https://github.com/cisagov/cyhy_amis/pull/911), and we need to do this to take advantage of the larger memory and number of processors.

## 🧪 Testing ##

We made this same change in production and found that reporting completed successfully and faster.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Pre-merge checklist ##

- [x] Finalize version.

## ✅ Post-merge checklist ##

- [x] Create a release (necessary if and only if the version was bumped).
- [x] Create cisagov/ansible-role-cyhy-reports#93 to start installing the new version of this repo.
