### PR TITLE
Increase PAUSE_ITERATION_LIMIT to 120

### DIFF
--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -816,7 +816,7 @@ def sync_all_tallies(db):
 
 def pause_commander(db):
     # number of iterations to wait before giving up
-    PAUSE_ITERATION_LIMIT = 90
+    PAUSE_ITERATION_LIMIT = 120
 
     # number of seconds to wait between each check to see
     # if the commander has paused

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ extra_files = package_files("cyhy_report/assets")
 
 setup(
     name="cyhy-reports",
-    version="1.1.1",
+    version="1.1.2",
     author="Mark Feldhousen Jr.",
     author_email="mark.feldhousen@hq.dhs.gov",
     packages=[


### PR DESCRIPTION


<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Increase the `PAUSE_ITERATION_LIMIT` in `extras/create_snapshots_reports_scorecard.py` from 90 to 120, which will let the reporting script wait up to 120 minutes for the commander to pause prior to starting reporting.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We have observed occasional commander cycles longer than 90 minutes, so it makes sense to bump up the limit here to work with commander cycles up to 120 minutes.

Note that I have already updated this value in Production.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Visual inspection.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release (necessary if and only if the version was bumped).
