### PR TITLE
Encrypt PDF with one key instead of two

### DIFF
--- a/cyhy_report/customer/generate_report.py
+++ b/cyhy_report/customer/generate_report.py
@@ -3607,7 +3607,7 @@ class ReportGenerator(object):
         assert return_code == 0, "xelatex pass 3 of 3 return code was %s" % return_code
 
     def __encrypt_pdf(self, name_in, name_out, report_key):
-        """Encrypt a PDF file with a key."""
+        """Encrypt a report PDF file with a key."""
         pdf_writer = PdfFileWriter()
 
         with file(name_in, "rb") as f_in:

--- a/cyhy_report/customer/generate_report.py
+++ b/cyhy_report/customer/generate_report.py
@@ -214,7 +214,7 @@ class ReportGenerator(object):
         title_date=None,
         final=False,
         anonymize=False,
-        encrypt_key=None,
+        encrypt=False,
         log_report=True,
     ):
         self.__cyhy_db = cyhy_db
@@ -231,7 +231,7 @@ class ReportGenerator(object):
         self.__title_date = title_date
         self.__draft = not final
         self.__anonymize = anonymize
-        self.__encrypt_key = encrypt_key
+        self.__encrypt = encrypt
         self.__report_oid = ObjectId()
         self.__generated_time = utcnow()
         self.__log_report_to_db = log_report
@@ -289,7 +289,7 @@ class ReportGenerator(object):
         self.__run_queries()
 
         # store key if present
-        owner_key = self.__results["owner"].get("key", None)
+        report_key = self.__results["owner"].get("key", None)
 
         # anonymize data if requested
         if self.__anonymize:
@@ -356,9 +356,9 @@ class ReportGenerator(object):
         self.__generate_final_pdf()
 
         # encrypt if requested and possible
-        if self.__encrypt_key != None and owner_key != None:
+        if self.__encrypt and report_key != None:
             self.__encrypt_pdf(
-                REPORT_PDF, ENCRYPTED_REPORT_PDF, self.__encrypt_key, owner_key
+                REPORT_PDF, ENCRYPTED_REPORT_PDF, report_key
             )
             shutil.move(ENCRYPTED_REPORT_PDF, REPORT_PDF)
             was_encrypted = True
@@ -3606,7 +3606,8 @@ class ReportGenerator(object):
         )
         assert return_code == 0, "xelatex pass 3 of 3 return code was %s" % return_code
 
-    def __encrypt_pdf(self, name_in, name_out, user_key, owner_key):
+    def __encrypt_pdf(self, name_in, name_out, report_key):
+        """Encrypt a PDF file with a key."""
         pdf_writer = PdfFileWriter()
         pdf_reader = PdfFileReader(open(name_in, "rb"))
 
@@ -3617,7 +3618,7 @@ class ReportGenerator(object):
         for i in xrange(pdf_reader.getNumPages()):
             pdf_writer.addPage(pdf_reader.getPage(i))
 
-        pdf_writer.encrypt(user_pwd=user_key, owner_pwd=owner_key.encode("ascii"))
+        pdf_writer.encrypt(user_pwd=report_key.encode("ascii"))
 
         with file(name_out, "wb") as f:
             pdf_writer.write(f)
@@ -3652,11 +3653,6 @@ def main():
         else:
             title_date = None
 
-        if args["--encrypt"]:
-            report_key = Config(args["--cyhy-section"]).report_key
-        else:
-            report_key = None
-
         print "Generating report for %s ..." % (owner),
         generator = ReportGenerator(
             cyhy_db,
@@ -3667,7 +3663,7 @@ def main():
             title_date=title_date,
             final=args["--final"],
             anonymize=args["--anonymize"],
-            encrypt_key=report_key,
+            encrypt=args["--encrypt"],
             log_report=not args["--nolog"],
         )
         was_encrypted, results = generator.generate_report()

--- a/cyhy_report/customer/generate_report.py
+++ b/cyhy_report/customer/generate_report.py
@@ -356,7 +356,7 @@ class ReportGenerator(object):
         self.__generate_final_pdf()
 
         # encrypt if requested and possible
-        if self.__encrypt and report_key != None:
+        if self.__encrypt and report_key is not None:
             self.__encrypt_pdf(
                 REPORT_PDF, ENCRYPTED_REPORT_PDF, report_key
             )

--- a/cyhy_report/customer/generate_report.py
+++ b/cyhy_report/customer/generate_report.py
@@ -3636,7 +3636,7 @@ class ReportGenerator(object):
 
 
 def main():
-    args = docopt(__doc__, version="v1.1.0")
+    args = docopt(__doc__, version="v2.0.0")
     cyhy_db = database.db_from_config(args["--cyhy-section"])
     scan_db = database.db_from_config(args["--scan-section"])
 

--- a/cyhy_report/customer/generate_report.py
+++ b/cyhy_report/customer/generate_report.py
@@ -10,8 +10,8 @@ Usage:
 Options:
   -a --anonymize                 Make a sample anonymous report.
   -d --debug                     Keep intermediate files for debugging.
-  -e --encrypt                   Encrypt with config key and owner keys if
-                                   the owner has a key in the datastore.
+  -e --encrypt                   Encrypt with owner key if the owner has a
+                                 key in the datastore.
   -f --final                     Remove draft watermark.
   -h --help                      Show this screen.
   -n --nolog                     Do not log that this report was created.

--- a/cyhy_report/customer/generate_report.py
+++ b/cyhy_report/customer/generate_report.py
@@ -3609,19 +3609,23 @@ class ReportGenerator(object):
     def __encrypt_pdf(self, name_in, name_out, report_key):
         """Encrypt a PDF file with a key."""
         pdf_writer = PdfFileWriter()
-        pdf_reader = PdfFileReader(open(name_in, "rb"))
 
-        # metadata copy hack see: http://stackoverflow.com/questions/2574676/change-metadata-of-pdf-file-with-pypdf
-        metadata = pdf_reader.getDocumentInfo()
-        pdf_writer._info.getObject().update(metadata)  # copy metadata to dest
+        with file(name_in, "rb") as f_in:
+            pdf_reader = PdfFileReader(f_in)
+            # Metadata copy hack see:
+            # http://stackoverflow.com/questions/2574676/change-metadata-of-pdf-file-with-pypdf
+            metadata = pdf_reader.getDocumentInfo()
 
-        for i in xrange(pdf_reader.getNumPages()):
-            pdf_writer.addPage(pdf_reader.getPage(i))
+            # Copy metadata to destination
+            pdf_writer._info.getObject().update(metadata)
 
-        pdf_writer.encrypt(user_pwd=report_key.encode("ascii"))
+            for i in xrange(pdf_reader.getNumPages()):
+                pdf_writer.addPage(pdf_reader.getPage(i))
 
-        with file(name_out, "wb") as f:
-            pdf_writer.write(f)
+            pdf_writer.encrypt(user_pwd=report_key.encode("ascii"))
+
+            with file(name_out, "wb") as f_out:
+                pdf_writer.write(f_out)
 
     def __log_report(self):
         report = self.__cyhy_db.ReportDoc()

--- a/cyhy_report/cyhy_notification/_version.py
+++ b/cyhy_report/cyhy_notification/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "1.1.0"
+__version__ = "2.0.0"

--- a/cyhy_report/cyhy_notification/generate_notification.py
+++ b/cyhy_report/cyhy_notification/generate_notification.py
@@ -142,7 +142,7 @@ class NotificationGenerator(object):
         debug=False,
         final=False,
         anonymize=False,
-        encrypt_key=None,
+        encrypt=False,
     ):
         """Construct a NotificationGenerator."""
         self.__cyhy_db = cyhy_db
@@ -151,7 +151,7 @@ class NotificationGenerator(object):
         self.__debug = debug
         self.__draft = not final
         self.__anonymize = anonymize
-        self.__encrypt_key = encrypt_key
+        self.__encrypt = encrypt
         self.__generated_time = utcnow()
 
     def generate_notification(self):
@@ -182,7 +182,7 @@ class NotificationGenerator(object):
             return False, self.__results
 
         # Store key if present
-        owner_key = self.__results["owner_request_doc"].get("key")
+        report_key = self.__results["owner_request_doc"].get("key")
 
         # Anonymize data if requested
         if self.__anonymize:
@@ -222,12 +222,11 @@ class NotificationGenerator(object):
             sys.exit(pdf_generated_rc)
 
         # Encrypt if requested and possible
-        if self.__encrypt_key is not None and owner_key is not None:
+        if self.__encrypt and report_key is not None:
             self.__encrypt_pdf(
                 NOTIFICATION_PDF,
                 ENCRYPTED_NOTIFICATION_PDF,
-                self.__encrypt_key,
-                owner_key,
+                report_key,
             )
             shutil.move(ENCRYPTED_NOTIFICATION_PDF, NOTIFICATION_PDF)
             was_encrypted = True
@@ -650,8 +649,8 @@ class NotificationGenerator(object):
 
         return return_code
 
-    def __encrypt_pdf(self, name_in, name_out, user_key, owner_key):
-        """Encrypt a PDF file with both a user key and an owner key."""
+    def __encrypt_pdf(self, name_in, name_out, report_key):
+        """Encrypt a PDF file with a key."""
         pdf_writer = PdfFileWriter()
         pdf_reader = PdfFileReader(open(name_in, "rb"))
 
@@ -663,7 +662,7 @@ class NotificationGenerator(object):
         for i in xrange(pdf_reader.getNumPages()):
             pdf_writer.addPage(pdf_reader.getPage(i))
 
-        pdf_writer.encrypt(user_pwd=user_key, owner_pwd=owner_key.encode("ascii"))
+        pdf_writer.encrypt(user_pwd=report_key.encode("ascii"))
 
         with file(name_out, "wb") as f:
             pdf_writer.write(f)
@@ -687,11 +686,6 @@ def main():
     cyhy_db = database.db_from_config(args["--cyhy-section"])
 
     for owner in args["OWNER"]:
-        if args["--encrypt"]:
-            report_key = Config(args["--cyhy-section"]).report_key
-        else:
-            report_key = None
-
         if args["--anonymize"]:
             print("Generating anonymized notification based on {} ...".format(owner)),
         else:
@@ -702,7 +696,7 @@ def main():
             debug=args["--debug"],
             final=args["--final"],
             anonymize=args["--anonymize"],
-            encrypt_key=report_key,
+            encrypt=args["--encrypt"],
         )
         was_encrypted, results = generator.generate_notification()
 

--- a/cyhy_report/cyhy_notification/generate_notification.py
+++ b/cyhy_report/cyhy_notification/generate_notification.py
@@ -649,7 +649,7 @@ class NotificationGenerator(object):
         return return_code
 
     def __encrypt_pdf(self, name_in, name_out, report_key):
-        """Encrypt a PDF file with a key."""
+        """Encrypt a report PDF file with a key."""
         pdf_writer = PdfFileWriter()
 
         with file(name_in, "rb") as f_in:

--- a/cyhy_report/cyhy_notification/generate_notification.py
+++ b/cyhy_report/cyhy_notification/generate_notification.py
@@ -651,20 +651,24 @@ class NotificationGenerator(object):
     def __encrypt_pdf(self, name_in, name_out, report_key):
         """Encrypt a PDF file with a key."""
         pdf_writer = PdfFileWriter()
-        pdf_reader = PdfFileReader(open(name_in, "rb"))
 
-        # Metadata copy hack see:
-        # http://stackoverflow.com/questions/2574676/change-metadata-of-pdf-file-with-pypdf
-        metadata = pdf_reader.getDocumentInfo()
-        pdf_writer._info.getObject().update(metadata)  # Copy metadata to dest
+        with file(name_in, "rb") as f_in:
+            pdf_reader = PdfFileReader(f_in)
 
-        for i in xrange(pdf_reader.getNumPages()):
-            pdf_writer.addPage(pdf_reader.getPage(i))
+            # Metadata copy hack see:
+            # http://stackoverflow.com/questions/2574676/change-metadata-of-pdf-file-with-pypdf
+            metadata = pdf_reader.getDocumentInfo()
 
-        pdf_writer.encrypt(user_pwd=report_key.encode("ascii"))
+            # Copy metadata to destination
+            pdf_writer._info.getObject().update(metadata)
 
-        with file(name_out, "wb") as f:
-            pdf_writer.write(f)
+            for i in xrange(pdf_reader.getNumPages()):
+                pdf_writer.addPage(pdf_reader.getPage(i))
+
+            pdf_writer.encrypt(user_pwd=report_key.encode("ascii"))
+
+            with file(name_out, "wb") as f_out:
+                pdf_writer.write(f_out)
 
     def __mark_notifications_as_generated(self):
         """Update notification documents in the database.

--- a/cyhy_report/cyhy_notification/generate_notification.py
+++ b/cyhy_report/cyhy_notification/generate_notification.py
@@ -37,7 +37,6 @@ from pyPdf import PdfFileWriter, PdfFileReader
 import unicodecsv as csv
 
 # cisagov Libraries
-from cyhy.core import Config
 from cyhy.db import database
 from cyhy.util import to_json, utcnow
 from cyhy_report.cyhy_notification._version import __version__

--- a/cyhy_report/cyhy_notification/generate_notification.py
+++ b/cyhy_report/cyhy_notification/generate_notification.py
@@ -10,8 +10,8 @@ Usage:
 Options:
   -a --anonymize                 Make a sample anonymous notification.
   -d --debug                     Keep intermediate files for debugging.
-  -e --encrypt                   Encrypt with config key and owner keys if
-                                   the owner has a key in the datastore.
+  -e --encrypt                   Encrypt with owner key if the owner has a
+                                 key in the datastore.
   -f --final                     Remove draft watermark.
   -h --help                      Show this screen.
   --version                      Show version.

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -97,7 +97,7 @@ def generate_notification_pdfs(db, org_ids, master_report_key):
     for org_id in org_ids:
         logging.info("{} - Starting to create notification PDF".format(org_id))
         generator = NotificationGenerator(
-            db, org_id, final=True, encrypt_key=master_report_key
+            db, org_id, final=True, encrypt=True,
         )
         was_encrypted, results = generator.generate_notification()
         if was_encrypted:

--- a/extras/create_send_notifications.py
+++ b/extras/create_send_notifications.py
@@ -22,7 +22,6 @@ import sys
 
 import docopt
 
-from cyhy.core import Config
 from cyhy.db import database
 from cyhy.util import util
 from cyhy_report.cyhy_notification import NotificationGenerator
@@ -91,7 +90,7 @@ def find_cyhy_parents(db, org_id):
         cyhy_parents.update(find_cyhy_parents(db, request["_id"]))
     return cyhy_parents
 
-def generate_notification_pdfs(db, org_ids, master_report_key): 
+def generate_notification_pdfs(db, org_ids): 
     """Generate all notification PDFs for a list of organizations."""
     num_pdfs_created = 0
     for org_id in org_ids:
@@ -141,8 +140,7 @@ def main():
     logging.debug("Will attempt to generate notifications for {} orgs: {}".format(len(notifications_org_ids), notifications_org_ids))
 
     # Create notification PDFs for CyHy orgs
-    master_report_key = Config(args["CYHY_DB_SECTION"]).report_key
-    num_pdfs_created = generate_notification_pdfs(db, notifications_org_ids, master_report_key)
+    num_pdfs_created = generate_notification_pdfs(db, notifications_org_ids)
     logging.info("{} notification PDFs created".format(num_pdfs_created))
 
     # Create a symlink to the latest notifications.  This is for the

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ extra_files = package_files("cyhy_report/assets")
 
 setup(
     name="cyhy-reports",
-    version="1.1.3",
+    version="2.0.0",
     author="Mark Feldhousen Jr.",
     author_email="mark.feldhousen@hq.dhs.gov",
     packages=[


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the `cyhy-reports` package, simplifying the PDF encryption process in both report and notification generation. The encryption logic now uses a single report key, and the related code paths and function signatures have been streamlined for clarity and maintainability.

I also took the opportunity to ensure that file handles are properly closed during the PDF encryption process (see https://github.com/cisagov/cyhy-reports/pull/138/commits/d0cb67bd9e5a42509b75e2ec035ce3dba0614d5b).

**Encryption logic simplification and standardization:**

* Replaced the use of separate `encrypt_key` and `owner_key` parameters with a single `encrypt` boolean flag and a single `report_key`, simplifying the encryption workflow in both `generate_report.py` and `generate_notification.py`. The `__encrypt_pdf` method now only requires one key, and the encryption is triggered based on the `encrypt` flag. [[1]](diffhunk://#diff-36857c588b2ae7b707e6f863b76aed538207072c08f00c8aa51c5c2634b4bc05L217-R217) [[2]](diffhunk://#diff-36857c588b2ae7b707e6f863b76aed538207072c08f00c8aa51c5c2634b4bc05L234-R234) [[3]](diffhunk://#diff-36857c588b2ae7b707e6f863b76aed538207072c08f00c8aa51c5c2634b4bc05L292-R292) [[4]](diffhunk://#diff-36857c588b2ae7b707e6f863b76aed538207072c08f00c8aa51c5c2634b4bc05L359-R361) [[5]](diffhunk://#diff-36857c588b2ae7b707e6f863b76aed538207072c08f00c8aa51c5c2634b4bc05L3609-R3610) [[6]](diffhunk://#diff-36857c588b2ae7b707e6f863b76aed538207072c08f00c8aa51c5c2634b4bc05L3620-R3621) [[7]](diffhunk://#diff-50c00b8a652d9b275bd0480411fb30bdb3c98775c4537259e6e5b7fa811a252cL145-R145) [[8]](diffhunk://#diff-50c00b8a652d9b275bd0480411fb30bdb3c98775c4537259e6e5b7fa811a252cL154-R154) [[9]](diffhunk://#diff-50c00b8a652d9b275bd0480411fb30bdb3c98775c4537259e6e5b7fa811a252cL185-R185) [[10]](diffhunk://#diff-50c00b8a652d9b275bd0480411fb30bdb3c98775c4537259e6e5b7fa811a252cL225-R229) [[11]](diffhunk://#diff-50c00b8a652d9b275bd0480411fb30bdb3c98775c4537259e6e5b7fa811a252cL653-R653) [[12]](diffhunk://#diff-50c00b8a652d9b275bd0480411fb30bdb3c98775c4537259e6e5b7fa811a252cL666-R665)

* Updated the main routines in both `generate_report.py` and `generate_notification.py` to use the new `encrypt` flag, removing unnecessary configuration logic for the report key and passing the flag directly to the generators. [[1]](diffhunk://#diff-36857c588b2ae7b707e6f863b76aed538207072c08f00c8aa51c5c2634b4bc05L3655-L3659) [[2]](diffhunk://#diff-36857c588b2ae7b707e6f863b76aed538207072c08f00c8aa51c5c2634b4bc05L3670-R3666) [[3]](diffhunk://#diff-50c00b8a652d9b275bd0480411fb30bdb3c98775c4537259e6e5b7fa811a252cL690-L694) [[4]](diffhunk://#diff-50c00b8a652d9b275bd0480411fb30bdb3c98775c4537259e6e5b7fa811a252cL705-R699)

**Versioning and metadata:**

* Bumped the version of the `cyhy-reports` package and its modules to `2.0.0` to reflect these breaking changes. [[1]](diffhunk://#diff-6123d23e75b4db521c75ade3acbe6ee2e21d5393776b5aca0c5a77ff33d44079L2-R2) [[2]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L17-R17)

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Previously, reports were encrypted with two keys- one stored in the report entity's request document and the other stored in the CyHy configuration file.  The decision was made to now only encrypt with the entity-specific key.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

To validate this change, I did the following:
* I generated a CyHy **report with encryption** and confirmed that the entity's key could unlock the PDF, while the key from the the CyHy configuration file could not. 
* I generated a CyHy **report without encryption** and confirmed that the PDF generated without errors and looked correct.
* I generated a CyHy **notification with encryption** and confirmed that the entity's key could unlock the PDF, while the key from the the CyHy configuration file could not. 
* I generated a CyHy **notification without encryption** and confirmed that the PDF generated without errors and looked correct.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release (necessary if and only if the version was bumped).
- [x] Deploy cyhy-notifications changes to Production
- [x] Deploy cyhy-reports changes to Production
