### PR TITLE
Use shell=False for the cyhy-reports container check

### DIFF
--- a/extras/create_snapshots_reports_scorecard.py
+++ b/extras/create_snapshots_reports_scorecard.py
@@ -935,10 +935,18 @@ def main():
     if use_docker == 1:
         if (
             subprocess.call(
-                "docker run --rm --volume /etc/cyhy:/etc/cyhy --volume {}:/home/cyhy {}/cyhy-reports:stable cyhy-report -h".format(
-                    WEEKLY_REPORT_BASE_DIR, NCATS_DHUB_URL
-                ),
-                shell=True,
+                [
+                    "docker",
+                    "run",
+                    "--rm",
+                    "--volume",
+                    "/etc/cyhy:/etc/cyhy",
+                    "--volume",
+                    "{}:/home/cyhy".format(WEEKLY_REPORT_BASE_DIR),
+                    "{}/cyhy-reports:stable".format(NCATS_DHUB_URL),
+                    "cyhy-report",
+                    "-h",
+                ]
             )
             != 0
         ):


### PR DESCRIPTION
Fixes #102.

The docker availability check ran its command through the shell:

```python
subprocess.call(
    "docker run --rm --volume /etc/cyhy:/etc/cyhy --volume {}:/home/cyhy {}/cyhy-reports:stable cyhy-report -h".format(
        WEEKLY_REPORT_BASE_DIR, NCATS_DHUB_URL
    ),
    shell=True,
)
```

As noted in the issue, `shell=True` spawns a shell to run the command, which widens the attack surface for no benefit here. The command is a fixed `docker run ... cyhy-report -h` with no shell features (no pipes, redirects, globbing or variable expansion), so it converts directly to an argument list and runs with the default `shell=False`.

The argument list is split exactly the way the shell would have word-split the original string, so the behavior is unchanged; it just removes the shell from the path. `WEEKLY_REPORT_BASE_DIR` and `NCATS_DHUB_URL` are now passed as discrete arguments, which also avoids any word-splitting surprises if either ever contained a space.

I confirmed the file still byte-compiles. I was not able to run this path end to end since it needs Docker and the CyHy environment, but the change is a mechanical string-to-list conversion of a single fixed command.