### PR TITLE
Fix bug in `generate_report.py` affecting descendant snapshots without hostnames

### DIFF
--- a/cyhy_report/customer/generate_report.py
+++ b/cyhy_report/customer/generate_report.py
@@ -2963,7 +2963,7 @@ class ReportGenerator(object):
                     }
                 elif self.__snapshots[0].get("descendants_included"):
                     for snap in snapshot_family:
-                        if hostname in snap["hostnames"]:
+                        if hostname in snap.get("hostnames", []):
                             break
                     row = {
                         "owner": snap["owner"],

--- a/cyhy_report/customer/generate_report.py
+++ b/cyhy_report/customer/generate_report.py
@@ -3640,7 +3640,7 @@ class ReportGenerator(object):
 
 
 def main():
-    args = docopt(__doc__, version="v2.0.0")
+    args = docopt(__doc__, version="v2.0.1")
     cyhy_db = database.db_from_config(args["--cyhy-section"])
     scan_db = database.db_from_config(args["--scan-section"])
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ extra_files = package_files("cyhy_report/assets")
 
 setup(
     name="cyhy-reports",
-    version="2.0.0",
+    version="2.0.1",
     author="Mark Feldhousen Jr.",
     author_email="mark.feldhousen@hq.dhs.gov",
     packages=[


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request includes a minor version bump for the `cyhy-reports` package and a small bug fix related to handling missing data. The most important changes are:

Version bump:

* Updated the version number from `2.0.0` to `2.0.1` in both `setup.py` and the CLI version output in `generate_report.py` to reflect the new release. [[1]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L17-R17) [[2]](diffhunk://#diff-36857c588b2ae7b707e6f863b76aed538207072c08f00c8aa51c5c2634b4bc05L3643-R3643)

Bug fix:

* Modified the code in `generate_report.py` to safely handle cases where the `hostnames` key might be missing from a snapshot by using `snap.get("hostnames", [])` instead of directly accessing `snap["hostnames"]`. This prevents a potential `KeyError`.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

During today's report generation run, one of the third-party reports failed to generate due to this error:

```console
Traceback (most recent call last):
  File "/usr/local/bin/cyhy-report", line 11, in <module>
    generate_report.main()
  File "/usr/local/lib/python2.7/dist-packages/cyhy_report/customer/generate_report.py", line 3673, in main
    was_encrypted, results = generator.generate_report()
  File "/usr/local/lib/python2.7/dist-packages/cyhy_report/customer/generate_report.py", line 347, in generate_report
    self.__generate_attachments()
  File "/usr/local/lib/python2.7/dist-packages/cyhy_report/customer/generate_report.py", line 2534, in __generate_attachments
    self.__generate_scope_host_attachment()
  File "/usr/local/lib/python2.7/dist-packages/cyhy_report/customer/generate_report.py", line 2966, in __generate_scope_host_attachment
    if hostname in snap["hostnames"]:
KeyError: 'hostnames'
```

Apparently we finally encountered a situation where a third-party report has hostnames in some, but not all descendant snapshots, which triggered the bug that is being fixed in this PR.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I tested this by re-generating the third-party report that failed to generate initially and it was successfully generated using the code change in this PR.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release (necessary if and only if the version was bumped).
