### PR TITLE
Fix log-scale y-axis handling in `MyLine.plot()`

### DIFF
--- a/cyhy_report/customer/generate_report.py
+++ b/cyhy_report/customer/generate_report.py
@@ -3235,7 +3235,7 @@ class ReportGenerator(object):
 
 
 def main():
-    args = docopt(__doc__, version="v2.1.0")
+    args = docopt(__doc__, version="v2.1.1")
     cyhy_db = database.db_from_config(args["--cyhy-section"])
     scan_db = database.db_from_config(args["--scan-section"])
 

--- a/cyhy_report/customer/graphs.py
+++ b/cyhy_report/customer/graphs.py
@@ -752,6 +752,19 @@ class MyLine(object):
             ax.set_xlabel(self.xlabel)
         if self.ylabel:
             ax.set_ylabel(self.ylabel)
+        if self.yscale == "log":
+            # A log-scaled y-axis cannot represent zero (or negative) values.
+            # If a series contains no positive values at all (e.g. an agency
+            # with zero critical vulnerabilities in every snapshot), letting
+            # matplotlib autoscale the axis raises "Data has no positive
+            # values, and therefore can not be log-scaled."  Setting the
+            # limits explicitly up front also disables y-axis autoscaling,
+            # which avoids that failure.  Note that zero values still cannot
+            # be drawn on a log axis, so such a series will not be visible.
+            max_positive = self.df[self.df > 0].max().max()
+            if pd.isnull(max_positive):
+                max_positive = 1.0
+            ax.set_ylim(0.8, max_positive * 1.5)
         colors = (c for c in self.linecolors)
         for col in self.df.columns:
             series = self.df[col]
@@ -782,7 +795,10 @@ class MyLine(object):
         leg.get_frame().set_alpha(0.5)
         ax.set_axisbelow(True)
         ax.yaxis.grid(True)
-        ax.set_ylim(ymin=0)  # Force y-axis to go to 0 (must be done after plot)
+        if self.yscale != "log":
+            # Force y-axis to go to 0 (must be done after plot).  Skipped for
+            # a log scale, where zero is not a valid limit.
+            ax.set_ylim(ymin=0)
         fig.set_tight_layout(True)
         plt.savefig(filename + ".pdf")
         plt.close()

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ extra_files = package_files("cyhy_report/assets")
 
 setup(
     name="cyhy-reports",
-    version="2.1.1",
+    version="2.1.2",
     author="Mark Feldhousen Jr.",
     author_email="mark.feldhousen@hq.dhs.gov",
     packages=[


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request introduces an important fix to plotting logic for log-scaled y-axes. The changes ensure that plots with log-scaled y-axes handle cases with no positive values gracefully, preventing runtime errors, and that y-axis limits are set appropriately depending on the scale.

Version updates:

* Bumped the package version in `setup.py` from `2.1.1` to `2.1.2` to reflect the new changes.
* Updated the version string in the CLI output of `generate_report.py` from `v2.1.0` to `v2.1.1`.

Plotting improvements in `graphs.py`:

* Added logic to set explicit y-axis limits for log-scaled plots, preventing errors when data contains no positive values and ensuring the plot displays correctly.
* Modified y-axis limit setting so that forcing the minimum to zero is skipped for log scales, where zero is not a valid value.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

When `__figure_all_vulns_over_time()` was introduced in #137, it failed to handle a specific case that affected one of our Production entities.  Their report generation crashed with `ValueError: Data has no positive values, and therefore can not be log-scaled`.

Consolidating the severity trend charts into a single "all vulnerabilities over time" figure means one shared y-scale now covers all four severities. `__best_scale()` selects a log scale when any severity has a wide spread, which is typically driven by large medium/low counts. If another severity has no positive values in that same chart, either all zeros, or all `NaN` when the severity key is absent from the snapshot data, matplotlib fails while autoscaling a log axis. This could not happen previously because criticals/highs and mediums/lows were separate figures, each with its own scale.

The fix sets the y-limits explicitly from the positive data before plotting when a log scale is in use, which also disables the autoscaling that raised the error. The pre-existing `set_ylim(ymin=0)` call is now skipped for log scales, where zero is not a valid limit.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I was able to successfully generate a report for the entity that crashed and revealed this error.  I also generated a couple other reports to spot check them and verified that everything looked normal. 

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release (necessary if and only if the version was bumped).
